### PR TITLE
Updated geoplot requirement to use main branch of its repository

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     extras_require={
         "docs": get_content("docs/requirements.txt"),
         "plotting": [
-            "GeoPlot @ git+ssh://git@github.com/antarctica/GeoPlot.git@pythonic_install",
+            "GeoPlot @ git+ssh://git@github.com/antarctica/GeoPlot.git",
         ],
         "tests": get_content("tests/requirements.txt"),
     },


### PR DESCRIPTION
Following merge of pythonoc_install, making polarroute track the main branch of that repository