### PR TITLE
Some autopep8 changes so code adheres to pep8 standards

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,7 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "bizstyle"#"agogo"
+html_theme = "bizstyle"  # "agogo"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/polar_route/cellbox.py
+++ b/polar_route/cellbox.py
@@ -26,7 +26,7 @@ import pandas as pd
 class CellBox:
     """
     A CellBox is a collection of data-points contained within a given geo-spatial/temporal
-    boundary. Information about any given value of a CellBox is calculated from 
+    boundary. Information about any given value of a CellBox is calculated from
     the mean of all data points of that type within those bounds. CellBoxes may
     be split into smaller CellBoxes and the data points within distributed
     between the newly created CellBoxes so as to construct a non-uniform mesh
@@ -101,7 +101,7 @@ class CellBox:
                 cx (float): the x-position of the top-left corner of the CellBox
                     given in degrees longitude.
         """
-        return self.long + self.width/2
+        return self.long + self.width / 2
 
     def getcy(self):
         """
@@ -111,17 +111,17 @@ class CellBox:
                 cy (float): the y-position of the top-left corner of the CellBox
                     given in degrees latitude.
         """
-        return self.lat + self.height/2
+        return self.lat + self.height / 2
 
     def getdcx(self):
         """
             returns x-distance from the edge to the centroid of the cellbox
 
             Returns:
-                dcx (float): the x-distance from the edge of the CellBox to the 
+                dcx (float): the x-distance from the edge of the CellBox to the
                     centroid of the CellBox. Given in degrees longitude
         """
-        return self.width/2
+        return self.width / 2
 
     def getdcy(self):
         """
@@ -131,7 +131,7 @@ class CellBox:
                 dxy (float): the y-distance from the edge of the CellBox to the
                     centroid of the CellBox. Given in degrees latitude
         """
-        return self.height/2
+        return self.height / 2
 
     def get_data_names(self):
         """
@@ -216,10 +216,10 @@ class CellBox:
                 bounds (list<tuples>): The geo-spatial boundaries of this CellBox.
         """
         bounds = [[self.long, self.lat],
-                    [self.long, self.lat + self.height],
-                    [self.long + self.width, self.lat + self.height],
-                    [self.long + self.width, self.lat],
-                    [self.long, self.lat]]
+                  [self.long, self.lat + self.height],
+                  [self.long + self.width, self.lat + self.height],
+                  [self.long + self.width, self.lat],
+                  [self.long, self.lat]]
         return bounds
 
     def get_value_out_types(self):
@@ -294,7 +294,6 @@ class CellBox:
             TODO
         """
         self._value_fill_types = value_fill_types
-
 
     # Functions used for splitting a cellbox
     def value_should_be_split(self, value, threshold, lowerbound, upperbound):
@@ -406,7 +405,7 @@ class CellBox:
             return "HOM"
         if "MIN" in hom_conditions:
             return "MIN"
-        if "HET" in hom_conditions: 
+        if "HET" in hom_conditions:
             return "HET"
         if hom_conditions.count("CLR") == len(hom_conditions):
             return "CLR"
@@ -466,7 +465,7 @@ class CellBox:
             upperbound = float(splitting_condition[value]['upperBound'])
             lowerbound = float(splitting_condition[value]['lowerBound'])
 
-            hom_conditions.append(self.value_hom_condition(value,threshold,lowerbound,upperbound))
+            hom_conditions.append(self.value_hom_condition(value, threshold, lowerbound, upperbound))
 
         if "HOM" in hom_conditions:
             return False
@@ -531,10 +530,10 @@ class CellBox:
                         fill_value = self.get_value(value, value_output_type)
                     else:
                         fill_value = np.nan
-              
+
                     if not np.isnan(fill_value):
                         datapoint = [[split_box.getcy(), split_box.getcx(), fill_value]]
-                        fill_df = pd.DataFrame(datapoint, columns=['lat','long',value])
+                        fill_df = pd.DataFrame(datapoint, columns=['lat', 'long', value])
 
                         split_box.add_data_points(fill_df)
 
@@ -620,8 +619,8 @@ class CellBox:
         else:
             for value in self.get_data_names():
                 if value in self.get_value_out_types().keys():
-                    cell_json[value] = float(self.get_value(value, 
-                        self.get_value_out_types()[value]))
+                    cell_json[value] = float(self.get_value(value,
+                                                            self.get_value_out_types()[value]))
                 else:
                     cell_json[value] = float(self.get_value(value))
 

--- a/polar_route/cli.py
+++ b/polar_route/cli.py
@@ -36,25 +36,24 @@ def get_args(
                     help="Turn on DEBUG level logging")
 
     if config_arg:
-        ap.add_argument("config", type=argparse.FileType("r"), 
-                    help="File location of configuration file used to build the mesh")
+        ap.add_argument("config", type=argparse.FileType("r"),
+                        help="File location of configuration file used to build the mesh")
 
     if info_arg:
         ap.add_argument("info", type=argparse.FileType("r"),
-                    help="File location of the enviromental mesh")
+                        help="File location of the enviromental mesh")
 
     if waypoints_arg:
         ap.add_argument("waypoints", type=argparse.FileType("r"))
         ap.add_argument("-p", "--path_only",
                         default=False,
-                        action = "store_true",
+                        action="store_true",
                         help="output only the calculated paths")
 
         ap.add_argument("-d", "--dijkstra",
                         default=False,
-                        action = "store_true",
+                        action="store_true",
                         help="output only the calculated paths")
-
 
     return ap.parse_args()
 
@@ -106,12 +105,12 @@ def optimise_routes_cli():
     from polar_route.route_planner import RoutePlanner
 
     args = get_args("optimise_routes.output.json",
-                    config_arg=False, info_arg=True, waypoints_arg= True)
+                    config_arg=False, info_arg=True, waypoints_arg=True)
     logging.info("{} {}".format(inspect.stack()[0][3][:-4], version))
 
     if args.path_only:
         logging.info("outputting only path to {}".format(args.output))
-    else: 
+    else:
         logging.info("outputting full mesh to {}".format(args.output))
 
     vehicle_mesh = json.load(args.info)
@@ -123,9 +122,9 @@ def optimise_routes_cli():
 
     if args.path_only:
         if args.dijkstra:
-             json.dump(info_dijkstra['paths'], open('{}_dijkstra.json'.format('.'.join(args.output.split('.')[:-1])), 'w'))
+            json.dump(info_dijkstra['paths'], open('{}_dijkstra.json'.format('.'.join(args.output.split('.')[:-1])), 'w'))
         json.dump(info['paths'], open(args.output, 'w'))
     else:
         if args.dijkstra:
-             json.dump(info_dijkstra, open('{}_dijkstra.json'.format('.'.join(args.output.split('.')[:-1])), 'w'))
+            json.dump(info_dijkstra, open('{}_dijkstra.json'.format('.'.join(args.output.split('.')[:-1])), 'w'))
         json.dump(info, open(args.output, "w"))

--- a/polar_route/crossing.py
+++ b/polar_route/crossing.py
@@ -27,9 +27,10 @@ class NewtonianDistance:
         attr2 (:obj:`int`, optional): Description of `attr2`.
 
     """
-    def __init__(self,source_graph=None,neighbour_graph=None,
-                 case=None,unit_shipspeed='km/hr',unit_time='days',
-                 zerocurrents=True,debugging=False,maxiter=1000,optimizer_tol=1e-3):
+
+    def __init__(self, source_graph=None, neighbour_graph=None,
+                 case=None, unit_shipspeed='km/hr', unit_time='days',
+                 zerocurrents=True, debugging=False, maxiter=1000, optimizer_tol=1e-3):
         """Example of docstring on the __init__ method.
 
         The __init__ method may be documented in either the class level
@@ -49,15 +50,15 @@ class NewtonianDistance:
 
         """
         # Cell information
-        self.source_graph     = source_graph
-        self.neighbour_graph  = neighbour_graph
+        self.source_graph = source_graph
+        self.neighbour_graph = neighbour_graph
 
         # Inside the code the base units are m/s. Changing the units of the inputs to match
-        self.unit_shipspeed  = unit_shipspeed
-        self.unit_time       = unit_time
-        self.source_speed    = self._unit_speed(self.source_graph['Speed'])
+        self.unit_shipspeed = unit_shipspeed
+        self.unit_time = unit_time
+        self.source_speed = self._unit_speed(self.source_graph['Speed'])
         self.neighbour_speed = self._unit_speed(self.neighbour_graph['Speed'])
-        self.case            = case
+        self.case = case
 
         if zerocurrents:
             self.zero_current_factor = 0.0
@@ -65,126 +66,126 @@ class NewtonianDistance:
             self.zero_current_factor = 1.0
 
         # Optimisation Information
-        self.maxiter       = maxiter
+        self.maxiter = maxiter
         self.optimizer_tol = optimizer_tol
 
         # Optimisation Information
-        self.m_long  = 111.321*1000
-        self.m_lat   = 111.386*1000
+        self.m_long = 111.321 * 1000
+        self.m_lat = 111.386 * 1000
 
         # Defining a small distance
         self.small_distance = 1e-4
 
         # For Debugging purposes
-        self.debugging     = debugging
+        self.debugging = debugging
 
     def _newton_optimisation(self, f, x, a, Y, u1, v1, u2, v2, s1, s2):
         '''
             FILL
         '''
-        y0 = (Y*x)/(x+a)
+        y0 = (Y * x) / (x + a)
         if self.debugging:
             print('---Initial y={:.2f}'.format(y0))
         improving = True
         iterartion_num = 0
         while improving:
-            F,dF,X1,X2,t1,t2  = f(y0,x,a,Y,u1,v1,u2,v2,s1,s2)
+            F, dF, X1, X2, t1, t2 = f(y0, x, a, Y, u1, v1, u2, v2, s1, s2)
             if self.debugging:
-                print('---Iteration {}: y={:.2f}; F={:.5f}; dF={:.2f}'\
-                      .format(iterartion_num,y0,F,dF))
-            y0  = y0 - (F/dF)
-            improving = abs((F/dF)/(X1*X2)) > self.optimizer_tol
-            iterartion_num+=1
-            if iterartion_num>1000:
+                print('---Iteration {}: y={:.2f}; F={:.5f}; dF={:.2f}'
+                      .format(iterartion_num, y0, F, dF))
+            y0 = y0 - (F / dF)
+            improving = abs((F / dF) / (X1 * X2)) > self.optimizer_tol
+            iterartion_num += 1
+            if iterartion_num > 1000:
                 raise Exception('Newton not able to converge')
-        return y0,self._unit_time(np.array([t1,t2]))
+        return y0, self._unit_time(np.array([t1, t2]))
 
-    def _unit_speed(self,val):
+    def _unit_speed(self, val):
         '''
             FILL
         '''
-        if not isinstance(val,type(None)):
+        if not isinstance(val, type(None)):
             if self.unit_shipspeed == 'km/hr':
-                val = val*(1000/(60*60))
+                val = val * (1000 / (60 * 60))
             if self.unit_shipspeed == 'knots':
-                val = (val*0.51)
+                val = (val * 0.51)
             return val
         else:
             return None
 
-    def _unit_time(self,val):
+    def _unit_time(self, val):
         '''
             FILL
         '''
         if self.unit_time == 'days':
-            val = val/(60*60*24.)
+            val = val / (60 * 60 * 24.)
         elif self.unit_time == 'hr':
-            val = val/(60*60.)
+            val = val / (60 * 60.)
         elif self.unit_time == 'min':
-            val = val/(60.)
+            val = val / (60.)
         elif self.unit_time == 's':
             val = val
         return val
 
-    def waypoint_correction(self,Wp,Cp):
+    def waypoint_correction(self, Wp, Cp):
         '''
             FILL
         '''
-        x = (Cp[0]-Wp[0])*self.m_long*np.cos(Wp[1]*(np.pi/180))
-        y = (Cp[1]-Wp[1])*self.m_lat
-        Su  = self.source_graph['Vector_x']*self.zero_current_factor
-        Sv  = self.source_graph['Vector_y']*self.zero_current_factor
+        x = (Cp[0] - Wp[0]) * self.m_long * np.cos(Wp[1] * (np.pi / 180))
+        y = (Cp[1] - Wp[1]) * self.m_lat
+        Su = self.source_graph['Vector_x'] * self.zero_current_factor
+        Sv = self.source_graph['Vector_y'] * self.zero_current_factor
         Ssp = self.source_speed
-        traveltime = self._traveltime_in_cell(x,y,Su,Sv,Ssp)
+        traveltime = self._traveltime_in_cell(x, y, Su, Sv, Ssp)
         return self._unit_time(traveltime)
 
-    def _F(self,y,x,a,Y,u1,v1,u2,v2,s1,s2):
+    def _F(self, y, x, a, Y, u1, v1, u2, v2, s1, s2):
         '''
             FILL
         '''
         C1 = s1**2 - u1**2 - v1**2
         C2 = s2**2 - u2**2 - v2**2
-        D1 = x*u1 + y*v1
-        D2 = a*u2 + (Y-y)*v2
-        X1ns = D1**2 + C1*(x**2 + y**2)
+        D1 = x * u1 + y * v1
+        D2 = a * u2 + (Y - y) * v2
+        X1ns = D1**2 + C1 * (x**2 + y**2)
         if X1ns < 0:
             X1 = -1
         else:
             X1 = np.sqrt(X1ns)
-        X2ns = D2**2 + C2*(a**2 + (Y-y)**2)
+        X2ns = D2**2 + C2 * (a**2 + (Y - y)**2)
         if X2ns < 0:
             X2 = -1
         else:
             X2 = np.sqrt(X2ns)
 
-        F  = X2*(y-((v1*(X1-D1))/C1)) + X1*(y-Y+((v2*(X2-D2))/C2))
+        F = X2 * (y - ((v1 * (X1 - D1)) / C1)) + X1 * (y - Y + ((v2 * (X2 - D2)) / C2))
 
         dD1 = v1
         dD2 = -v2
         if X1 == 0:
             dX1 = 0
         else:
-            dX1 = (D1*v1 + C1*y)/X1
-        if X2 ==0:
+            dX1 = (D1 * v1 + C1 * y) / X1
+        if X2 == 0:
             dX2 = 0
         else:
-            dX2 = (-D2*v2 - C2*(Y-y))/X2
-        dF  = (X1+X2) + y*(dX1 + dX2) - (v1/C1)*(dX2*(X1-D1) + X2*(dX1-dD1))\
-            + (v2/C2)*(dX1*(X2-D2)+X1*(dX2-dD2)) - Y*dX1
+            dX2 = (-D2 * v2 - C2 * (Y - y)) / X2
+        dF = (X1 + X2) + y * (dX1 + dX2) - (v1 / C1) * (dX2 * (X1 - D1) + X2 * (dX1 - dD1))\
+            + (v2 / C2) * (dX1 * (X2 - D2) + X1 * (dX2 - dD2)) - Y * dX1
 
-        t1 = (X1-D1)/C1
-        t2 = (X2-D2)/C2
+        t1 = (X1 - D1) / C1
+        t2 = (X2 - D2) / C2
 
-        return F,dF,X1,X2,t1,t2
+        return F, dF, X1, X2, t1, t2
 
-    def _traveltime_in_cell(self,xdist,ydist,U,V,S):
+    def _traveltime_in_cell(self, xdist, ydist, U, V, S):
         '''
             Determines the travel-time within cell between two points
         '''
-        dist  = np.sqrt(xdist**2 + ydist**2)
-        cval  = np.sqrt(U**2 + V**2)
+        dist = np.sqrt(xdist**2 + ydist**2)
+        cval = np.sqrt(U**2 + V**2)
 
-        dotprod  = xdist*U + ydist*V
+        dotprod = xdist * U + ydist * V
         diffsqrs = S**2 - cval**2
 
         # if (dotprod**2 + diffsqrs*(dist**2) < 0)
@@ -193,14 +194,14 @@ class NewtonianDistance:
                 return np.inf
                 #raise Exception(' ')
             else:
-                if ((dist**2)/(2*dotprod))  <0:
+                if ((dist**2) / (2 * dotprod)) < 0:
                     return np.inf
                     #raise Exception(' ')
                 else:
                     traveltime = dist * dist / (2 * dotprod)
                     return traveltime
 
-        traveltime = (np.sqrt(dotprod**2 + (dist**2)*diffsqrs) - dotprod)/diffsqrs
+        traveltime = (np.sqrt(dotprod**2 + (dist**2) * diffsqrs) - dotprod) / diffsqrs
         if traveltime < 0:
             traveltime = np.inf
             #raise Exception('Newton Corner Cases returning Zero Traveltime - ISSUE')
@@ -211,142 +212,135 @@ class NewtonianDistance:
             FILL
         '''
 
-        if self.case==2:
+        if self.case == 2:
             ptvl = 1.0
         else:
             ptvl = -1.0
 
-        s_cx  = self.source_graph['cx']
-        s_cy  = self.source_graph['cy']
+        s_cx = self.source_graph['cx']
+        s_cy = self.source_graph['cy']
         s_dcx = self.source_graph['dcx']
         s_dcy = self.source_graph['dcy']
-        n_cx  = self.neighbour_graph['cx']
-        n_cy  = self.neighbour_graph['cy']
+        n_cx = self.neighbour_graph['cx']
+        n_cy = self.neighbour_graph['cy']
         n_dcx = self.neighbour_graph['dcx']
         n_dcy = self.neighbour_graph['dcy']
 
-
-        Su = ptvl*self.source_graph['Vector_x']*self.zero_current_factor
-        Sv = ptvl*self.source_graph['Vector_y']*self.zero_current_factor
-        Nu = ptvl*self.neighbour_graph['Vector_x']*self.zero_current_factor
-        Nv = ptvl*self.neighbour_graph['Vector_y']*self.zero_current_factor
+        Su = ptvl * self.source_graph['Vector_x'] * self.zero_current_factor
+        Sv = ptvl * self.source_graph['Vector_y'] * self.zero_current_factor
+        Nu = ptvl * self.neighbour_graph['Vector_x'] * self.zero_current_factor
+        Nv = ptvl * self.neighbour_graph['Vector_y'] * self.zero_current_factor
 
         Ssp = self.source_speed
         Nsp = self.neighbour_speed
 
-
-        x = s_dcx*self.m_long*np.cos(s_cy*(np.pi/180))
-        a = n_dcx*self.m_long*np.cos(n_cy*(np.pi/180))
-        Y = ptvl*(n_cy-s_cy)*self.m_lat
+        x = s_dcx * self.m_long * np.cos(s_cy * (np.pi / 180))
+        a = n_dcx * self.m_long * np.cos(n_cy * (np.pi / 180))
+        Y = ptvl * (n_cy - s_cy) * self.m_lat
 
         # Optimising to determine the y-value of the crossing point
-        y,TravelTime = self._newton_optimisation(self._F,x,a,Y,Su,Sv,Nu,Nv,Ssp,Nsp)
-        CrossPoints = (s_cx+ptvl*s_dcx,\
-                       s_cy+ptvl*y/self.m_lat)
-        CellPoints  = [n_cx,n_cy]
+        y, TravelTime = self._newton_optimisation(self._F, x, a, Y, Su, Sv, Nu, Nv, Ssp, Nsp)
+        CrossPoints = (s_cx + ptvl * s_dcx,
+                       s_cy + ptvl * y / self.m_lat)
+        CellPoints = [n_cx, n_cy]
 
-        return TravelTime,CrossPoints,CellPoints
+        return TravelTime, CrossPoints, CellPoints
 
     def _latitude(self):
         '''
             FILL
         '''
 
-        if self.case==4:
+        if self.case == 4:
             ptvl = 1.0
         else:
             ptvl = -1.0
 
-        s_cx  = self.source_graph['cx']
-        s_cy  = self.source_graph['cy']
+        s_cx = self.source_graph['cx']
+        s_cy = self.source_graph['cy']
         s_dcx = self.source_graph['dcx']
         s_dcy = self.source_graph['dcy']
-        n_cx  = self.neighbour_graph['cx']
-        n_cy  = self.neighbour_graph['cy']
+        n_cx = self.neighbour_graph['cx']
+        n_cy = self.neighbour_graph['cy']
         n_dcx = self.neighbour_graph['dcx']
         n_dcy = self.neighbour_graph['dcy']
 
+        Su = -1 * ptvl * self.source_graph['Vector_y'] * self.zero_current_factor
+        Sv = ptvl * self.source_graph['Vector_x'] * self.zero_current_factor
+        Nu = -1 * ptvl * self.neighbour_graph['Vector_y'] * self.zero_current_factor
+        Nv = ptvl * self.neighbour_graph['Vector_x'] * self.zero_current_factor
 
-        Su = -1*ptvl*self.source_graph['Vector_y']*self.zero_current_factor
-        Sv = ptvl*self.source_graph['Vector_x']*self.zero_current_factor
-        Nu = -1*ptvl*self.neighbour_graph['Vector_y']*self.zero_current_factor
-        Nv = ptvl*self.neighbour_graph['Vector_x']*self.zero_current_factor
+        Ssp = self.source_speed
+        Nsp = self.neighbour_speed
 
-        Ssp=self.source_speed
-        Nsp=self.neighbour_speed
+        x = s_dcy * self.m_lat
+        a = n_dcy * self.m_lat
+        Y = ptvl * (n_cx - s_cx) * self.m_long * np.cos((n_cy + s_cy) * (np.pi / 180) / 2.0)
 
-        x = s_dcy*self.m_lat
-        a = n_dcy*self.m_lat
-        Y = ptvl*(n_cx-s_cx)*self.m_long*np.cos((n_cy+s_cy)*(np.pi/180)/2.0)
+        y, TravelTime = self._newton_optimisation(self._F, x, a, Y, Su, Sv, Nu, Nv, Ssp, Nsp)
+        clon = s_cx + ptvl * y / (self.m_long * np.cos((n_cy +
+                                                        s_cy) * (np.pi / 180) / 2.0))
+        clat = s_cy + -1 * ptvl * s_dcy
 
-        y,TravelTime   = self._newton_optimisation(self._F,x,a,Y,Su,Sv,Nu,Nv,Ssp,Nsp)
-        clon = s_cx  + ptvl*y/(self.m_long*np.cos((n_cy+\
-               s_cy)*(np.pi/180)/2.0))
-        clat = s_cy + -1*ptvl*s_dcy
+        CrossPoints = (clon, clat)
+        CellPoints = [n_cx, n_cy]
 
-        CrossPoints = (clon,clat)
-        CellPoints  = [n_cx,n_cy]
-
-        return TravelTime,CrossPoints,CellPoints
-
+        return TravelTime, CrossPoints, CellPoints
 
     def _corner(self):
         '''
             FILL
         '''
 
-
-        s_cx  = self.source_graph['cx']
-        s_cy  = self.source_graph['cy']
+        s_cx = self.source_graph['cx']
+        s_cy = self.source_graph['cy']
         s_dcx = self.source_graph['dcx']
         s_dcy = self.source_graph['dcy']
-        n_cx  = self.neighbour_graph['cx']
-        n_cy  = self.neighbour_graph['cy']
+        n_cx = self.neighbour_graph['cx']
+        n_cy = self.neighbour_graph['cy']
         n_dcx = self.neighbour_graph['dcx']
         n_dcy = self.neighbour_graph['dcy']
 
-
-
         # Given the determine the postive and negative position relative to centre
-        if self.case==1:
+        if self.case == 1:
             ptvX = 1.0
             ptvY = 1.0
-        elif self.case==-1:
+        elif self.case == -1:
             ptvX = -1.0
             ptvY = -1.0
-        elif self.case==3:
+        elif self.case == 3:
             ptvX = 1.0
             ptvY = -1.0
-        elif self.case==-3:
+        elif self.case == -3:
             ptvX = -1.0
             ptvY = 1.0
 
-        dx1 = s_dcx*self.m_long*np.cos(s_cy*(np.pi/180))
-        dx2 = n_dcx*self.m_long*np.cos(n_cy*(np.pi/180))
-        dy1 = s_dcy*self.m_lat
-        dy2 = n_dcy*self.m_lat
+        dx1 = s_dcx * self.m_long * np.cos(s_cy * (np.pi / 180))
+        dx2 = n_dcx * self.m_long * np.cos(n_cy * (np.pi / 180))
+        dy1 = s_dcy * self.m_lat
+        dy2 = n_dcy * self.m_lat
 
         # Currents in Cells
-        Su = ptvX*self.source_graph['Vector_x']*self.zero_current_factor
-        Sv = ptvY*self.source_graph['Vector_y']*self.zero_current_factor
-        Nu = ptvX*self.neighbour_graph['Vector_x']*self.zero_current_factor
-        Nv = ptvY*self.neighbour_graph['Vector_y']*self.zero_current_factor
+        Su = ptvX * self.source_graph['Vector_x'] * self.zero_current_factor
+        Sv = ptvY * self.source_graph['Vector_y'] * self.zero_current_factor
+        Nu = ptvX * self.neighbour_graph['Vector_x'] * self.zero_current_factor
+        Nv = ptvY * self.neighbour_graph['Vector_y'] * self.zero_current_factor
 
         # Vehicles Speeds in Cells
-        Ssp = self.source_speed; Nsp = self.neighbour_speed
+        Ssp = self.source_speed
+        Nsp = self.neighbour_speed
 
         # Determining the crossing point as the corner of the case
-        CrossPoints = [s_cx+ptvX*s_dcx,\
-                       s_cy+ptvY*s_dcy]
-        CellPoints  = [n_cx,n_cy]
+        CrossPoints = [s_cx + ptvX * s_dcx,
+                       s_cy + ptvY * s_dcy]
+        CellPoints = [n_cx, n_cy]
 
         # Determining traveltime
-        t1 = self._traveltime_in_cell(dx1,dy1,Su,Sv,Ssp)
-        t2 = self._traveltime_in_cell(dx2,dy2,Nu,Nv,Nsp)
-        TravelTime  = self._unit_time(np.array([t1,t2]))
+        t1 = self._traveltime_in_cell(dx1, dy1, Su, Sv, Ssp)
+        t2 = self._traveltime_in_cell(dx2, dy2, Nu, Nv, Nsp)
+        TravelTime = self._unit_time(np.array([t1, t2]))
 
-        return TravelTime,CrossPoints,CellPoints
-
+        return TravelTime, CrossPoints, CellPoints
 
     def value(self):
         '''
@@ -354,18 +348,18 @@ class NewtonianDistance:
         '''
         if self.debugging:
             print('============================================')
-        if abs(self.case)==2:
-            TravelTime,CrossPoints,CellPoints = self._longitude()
-        elif abs(self.case)==4:
-            TravelTime,CrossPoints,CellPoints = self._latitude()
-        elif abs(self.case)==1 or abs(self.case)==3:
-            TravelTime,CrossPoints,CellPoints = self._corner()
+        if abs(self.case) == 2:
+            TravelTime, CrossPoints, CellPoints = self._longitude()
+        elif abs(self.case) == 4:
+            TravelTime, CrossPoints, CellPoints = self._latitude()
+        elif abs(self.case) == 1 or abs(self.case) == 3:
+            TravelTime, CrossPoints, CellPoints = self._corner()
         else:
-            print('---> Issue with cell (Xsc,Ysc)={:.2f};{:.2f}'.\
-                format(self.source_graph['cx'],self.source_graph['cy']))
-            TravelTime  = [np.inf,np.inf]
-            CrossPoints = [np.nan,np.nan]
-            CellPoints  = [np.nan,np.nan]
+            print('---> Issue with cell (Xsc,Ysc)={:.2f};{:.2f}'.
+                  format(self.source_graph['cx'], self.source_graph['cy']))
+            TravelTime = [np.inf, np.inf]
+            CrossPoints = [np.nan, np.nan]
+            CellPoints = [np.nan, np.nan]
 
         return TravelTime, CrossPoints, CellPoints
 
@@ -379,7 +373,7 @@ class NewtonianDistance:
 
 
 class NewtonianCurve:
-    def __init__(self,neighbour_graph,config,unit_shipspeed='km/hr',unit_time='days',debugging=False,maxiter=1000,pathIter=5,optimizer_tol=1e-3,minimumDiff=1e-3,zerocurrents=True):
+    def __init__(self, neighbour_graph, config, unit_shipspeed='km/hr', unit_time='days', debugging=False, maxiter=1000, pathIter=5, optimizer_tol=1e-3, minimumDiff=1e-3, zerocurrents=True):
         '''
             FILL
         '''
@@ -389,29 +383,26 @@ class NewtonianCurve:
         # Passing the optional Information
         self.config = config
 
-        
         # Inside the code the base units are m/s. Changing the units of the inputs to match
         self.unit_shipspeed = unit_shipspeed
-        self.unit_time      = unit_time
+        self.unit_time = unit_time
 
-        
         # Information for distance metrics
-        self.R              = 6371.*1000
+        self.R = 6371. * 1000
 
         # Optimisation Information
-        self.maxiter       = maxiter
-        self.pathIter      = pathIter
+        self.maxiter = maxiter
+        self.pathIter = pathIter
         self.optimizer_tol = optimizer_tol
-        self.minimumDiff   = minimumDiff
-        self._epsilon      = 1e-3
-
+        self.minimumDiff = minimumDiff
+        self._epsilon = 1e-3
 
         # Optimisation Information
-        self.m_long  = 111.321*1000
-        self.m_lat   = 111.386*1000.
+        self.m_long = 111.321 * 1000
+        self.m_lat = 111.386 * 1000.
 
-        # For Debugging purposes 
-        self.debugging     = debugging
+        # For Debugging purposes
+        self.debugging = debugging
 
         if self.debugging:
             self.debugFile1 = open("debugFil.txt", "w")  # append mode
@@ -425,261 +416,262 @@ class NewtonianCurve:
         else:
             self.zc = 1.0
 
-    def _unit_speed(self,Val):
+    def _unit_speed(self, Val):
         '''
             FILL
         '''
         if self.unit_shipspeed == 'km/hr':
-            Val = Val*(1000/(60*60))
+            Val = Val * (1000 / (60 * 60))
         if self.unit_shipspeed == 'knots':
-            Val = (Val*0.51)
+            Val = (Val * 0.51)
         return Val
 
-    def _unit_time(self,Val):
+    def _unit_time(self, Val):
         '''
             FILL
         '''
         if self.unit_time == 'days':
-            Val = Val/(60*60*24)
+            Val = Val / (60 * 60 * 24)
         elif self.unit_time == 'hr':
-            Val = Val/(60*60)
+            Val = Val / (60 * 60)
         elif self.unit_time == 'min':
-            Val = Val/(60)
+            Val = Val / (60)
         elif self.unit_time == 's':
             Val = Val
         return Val
 
+    def _calXDist(self, start_long, end_long):
+        '''
+            FILL
+        '''
+        return (end_long - start_long) * self.m_long  # *np.cos(centralLat)
 
-    def _calXDist(self,start_long,end_long):
+    def _calYDist(self, start_lat, end_lat):
         '''
             FILL
         '''
-        return (end_long - start_long)*self.m_long#*np.cos(centralLat)
-    def _calYDist(self,start_lat,end_lat):
-        '''
-            FILL
-        '''
-        return (end_lat-start_lat)*self.m_lat
+        return (end_lat - start_lat) * self.m_lat
 
     def _long_case(self):
         '''
             FILL
         '''
-        def NewtonOptimisationLong(f,y0,x,a,Y,u1,v1,u2,v2,speed_s,speed_e,R,λ_s,φ_r):
-                tryNum=1
-                iter=0
-                improving=True
-                while improving:  
-                    F,dF,X1,X2  = f(y0,x,a,Y,u1,v1,u2,v2,speed_s,speed_e,R,λ_s,φ_r)
-                    if (F==0) or (dF==0):
-                        dY = 0
-                    else:
-                        dY = (F/dF)
-                    improving =  (abs(dY)>self._epsilon) or (abs(dY) > self._epsilon*(X1*X2) and (abs(dY)/iter) > self._epsilon)
-                    y0  -= dY
-                    iter+=1
+        def NewtonOptimisationLong(f, y0, x, a, Y, u1, v1, u2, v2, speed_s, speed_e, R, λ_s, φ_r):
+            tryNum = 1
+            iter = 0
+            improving = True
+            while improving:
+                F, dF, X1, X2 = f(y0, x, a, Y, u1, v1, u2, v2, speed_s, speed_e, R, λ_s, φ_r)
+                if (F == 0) or (dF == 0):
+                    dY = 0
+                else:
+                    dY = (F / dF)
+                improving = (abs(dY) > self._epsilon) or (abs(dY) > self._epsilon * (X1 * X2) and (abs(dY) / iter) > self._epsilon)
+                y0 -= dY
+                iter += 1
 
-                    if (iter>100 and tryNum == 1):
-                        y0 = Y*x/(x+a)
-                        tryNum+=1
-                    if (iter > 200) and tryNum>= 2 and tryNum < 10:
-                        tryNum+=1
-                        iter-=100
-                        if(Y < 0):
-                            if v2>v1:
-                                y0 = (tryNum-2)*Y
-                            else:
-                                y0 = (tryNum-3)*-Y
+                if (iter > 100 and tryNum == 1):
+                    y0 = Y * x / (x + a)
+                    tryNum += 1
+                if (iter > 200) and tryNum >= 2 and tryNum < 10:
+                    tryNum += 1
+                    iter -= 100
+                    if(Y < 0):
+                        if v2 > v1:
+                            y0 = (tryNum - 2) * Y
                         else:
-                            if (v2<v1):
-                                y0 = (tryNum-2)*Y
-                            else:
-                                y0 = (tryNum-3)*-Y
-                    if iter > 1000:
-                        raise Exception('Newton Curve Issue')
-                return y0
+                            y0 = (tryNum - 3) * -Y
+                    else:
+                        if (v2 < v1):
+                            y0 = (tryNum - 2) * Y
+                        else:
+                            y0 = (tryNum - 3) * -Y
+                if iter > 1000:
+                    raise Exception('Newton Curve Issue')
+            return y0
 
-        def _F(y,x,a,Y,u1,v1,u2,v2,speed_s,speed_e,R,λ_s,φ_r):
-            θ  = (y/R + λ_s*(np.pi/180))
-            zl = x*np.cos(θ)
-            ψ  = (-(Y-y)/R + φ_r*(np.pi/180))
-            zr = a*np.cos(ψ)
+        def _F(y, x, a, Y, u1, v1, u2, v2, speed_s, speed_e, R, λ_s, φ_r):
+            θ = (y / R + λ_s * (np.pi / 180))
+            zl = x * np.cos(θ)
+            ψ = (-(Y - y) / R + φ_r * (np.pi / 180))
+            zr = a * np.cos(ψ)
 
-            C1  = speed_s**2 - u1**2 - v1**2
-            C2  = speed_e**2 - u2**2 - v2**2
-            D1  = zl*u1 + y*v1
-            D2  = zr*u2 + (Y-y)*v2
-            X1  = np.sqrt(D1**2 + C1*(zl**2 + y**2))
-            X2  = np.sqrt(D2**2 + C2*(zr**2 + (Y-y)**2))
+            C1 = speed_s**2 - u1**2 - v1**2
+            C2 = speed_e**2 - u2**2 - v2**2
+            D1 = zl * u1 + y * v1
+            D2 = zr * u2 + (Y - y) * v2
+            X1 = np.sqrt(D1**2 + C1 * (zl**2 + y**2))
+            X2 = np.sqrt(D2**2 + C2 * (zr**2 + (Y - y)**2))
 
-            dzr = -zr*np.sin(ψ)/R
-            dzl = -zl*np.sin(θ)/R
+            dzr = -zr * np.sin(ψ) / R
+            dzl = -zl * np.sin(θ) / R
 
-            dD1 = dzl*u1 + v1
-            dD2 = dzr*u2 - v2
-            dX1 = (D1*v1 + C1*y + dzl*(D1*u1 + C1*zl))/X1
-            dX2 = (-v2*D2 - C2*(Y-y) + dzr*(D2*u2 + C2*zr))/X2     
+            dD1 = dzl * u1 + v1
+            dD2 = dzr * u2 - v2
+            dX1 = (D1 * v1 + C1 * y + dzl * (D1 * u1 + C1 * zl)) / X1
+            dX2 = (-v2 * D2 - C2 * (Y - y) + dzr * (D2 * u2 + C2 * zr)) / X2
 
-            zr_term = (zr - (X2 - D2)*u2/C2)
-            zl_term = (zl - (X1 - D1)*u1/C1)
+            zr_term = (zr - (X2 - D2) * u2 / C2)
+            zl_term = (zl - (X1 - D1) * u1 / C1)
 
-            F = (X1+X2)*y - v1*(X1-D1)*X2/C1 - (Y - v2*(X2-D2)/C2)*X1 + dzr*zr_term*X1 + dzl*zl_term*X2
+            F = (X1 + X2) * y - v1 * (X1 - D1) * X2 / C1 - (Y - v2 * (X2 - D2) / C2) * X1 + dzr * zr_term * X1 + dzl * zl_term * X2
 
-            dF = (X1+X2) + y*(dX1 + dX2) - (v1/C1)*(dX2*(X1-D1) + X2*(dX1-dD1))\
-                - Y*dX1 + (v2/C2)*(dX1*(X2-D2) + X1*(dX2-dD2))\
-                - (zr/(R**2))*zr_term*X1\
-                - (zl/(R**2))*zl_term*X2\
-                + dzr*(dzr-u2*(dX2-dD2))/C2*X1\
-                + dzl*(dzl-u1*(dX1-dD1))/C1*X2\
-                + dzr*zr_term*dX1 + dzl*zl_term*dX2
+            dF = (X1 + X2) + y * (dX1 + dX2) - (v1 / C1) * (dX2 * (X1 - D1) + X2 * (dX1 - dD1))\
+                - Y * dX1 + (v2 / C2) * (dX1 * (X2 - D2) + X1 * (dX2 - dD2))\
+                - (zr / (R**2)) * zr_term * X1\
+                - (zl / (R**2)) * zl_term * X2\
+                + dzr * (dzr - u2 * (dX2 - dD2)) / C2 * X1\
+                + dzl * (dzl - u1 * (dX1 - dD1)) / C1 * X2\
+                + dzr * zr_term * dX1 + dzl * zl_term * dX2
 
-            return F,dF,X1,X2
+            return F, dF, X1, X2
 
-        Sp   = tuple(self.triplet[['cx','cy']].iloc[0])
-        Cp   = tuple(self.triplet[['cx','cy']].iloc[1])
-        Np   = tuple(self.triplet[['cx','cy']].iloc[2])
+        Sp = tuple(self.triplet[['cx', 'cy']].iloc[0])
+        Cp = tuple(self.triplet[['cx', 'cy']].iloc[1])
+        Np = tuple(self.triplet[['cx', 'cy']].iloc[2])
 
-        cell_s_u = self.neighbour_graph.loc[self.triplet.iloc[1]['cellStart'].name,'Vector_x']
-        cell_s_v = self.neighbour_graph.loc[self.triplet.iloc[1]['cellStart'].name,'Vector_y']
-        cell_e_u = self.neighbour_graph.loc[self.triplet.iloc[1]['cellEnd'].name,'Vector_x']
-        cell_e_v = self.neighbour_graph.loc[self.triplet.iloc[1]['cellEnd'].name,'Vector_y']
+        cell_s_u = self.neighbour_graph.loc[self.triplet.iloc[1]['cellStart'].name, 'Vector_x']
+        cell_s_v = self.neighbour_graph.loc[self.triplet.iloc[1]['cellStart'].name, 'Vector_y']
+        cell_e_u = self.neighbour_graph.loc[self.triplet.iloc[1]['cellEnd'].name, 'Vector_x']
+        cell_e_v = self.neighbour_graph.loc[self.triplet.iloc[1]['cellEnd'].name, 'Vector_y']
 
-        if self.triplet.iloc[1].case == 2:   
-            sgn  = 1
+        if self.triplet.iloc[1].case == 2:
+            sgn = 1
         else:
-            sgn  = -1
+            sgn = -1
 
-        λ_s  = Sp[1]
-        φ_r  = Np[1]
+        λ_s = Sp[1]
+        φ_r = Np[1]
 
-        x           = sgn*self._calXDist(Sp[0],Cp[0])
-        a           = sgn*self._calXDist(Cp[0],Np[0])
-        Y           = (Np[1]-Sp[1])*self.m_lat
-        y0          = Y/2
-        u1          = sgn*self.zc*cell_s_u; v1 = self.zc*cell_s_v
-        u2          = sgn*self.zc*cell_e_u; v2 = self.zc*cell_e_v
-        y           = NewtonOptimisationLong(_F,y0,x,a,Y,u1,v1,u2,v2,self.speed_s,self.speed_e,self.R,λ_s,φ_r)
+        x = sgn * self._calXDist(Sp[0], Cp[0])
+        a = sgn * self._calXDist(Cp[0], Np[0])
+        Y = (Np[1] - Sp[1]) * self.m_lat
+        y0 = Y / 2
+        u1 = sgn * self.zc * cell_s_u
+        v1 = self.zc * cell_s_v
+        u2 = sgn * self.zc * cell_e_u
+        v2 = self.zc * cell_e_v
+        y = NewtonOptimisationLong(_F, y0, x, a, Y, u1, v1, u2, v2, self.speed_s, self.speed_e, self.R, λ_s, φ_r)
 
         # Updating the crossing points
         self.triplet['cx'].iloc[1] = Cp[0]
-        self.triplet['cy'].iloc[1] = Sp[1] + y/self.m_lat
-
+        self.triplet['cy'].iloc[1] = Sp[1] + y / self.m_lat
 
     def _lat_case(self):
         '''
             FILL
         '''
-        def NewtonOptimisationLat(f,y0,x,a,Y,u1,v1,u2,v2,speed_s,speed_e,R,λ,θ,ψ):
-                tryNum=1
-                iter=0
-                improving=True
-                while improving:  
-                    F,dF,X1,X2  = f(y0,x,a,Y,u1,v1,u2,v2,speed_s,speed_e,R,λ,θ,ψ)
-                    if (F==0) or (dF==0):
-                        dY = 0
-                    else:
-                        dY = (F/dF)
-                    improving =abs(dY) > 1 or (abs(dY) > self._epsilon*(X1*X2) and (abs(dY)/iter) > self._epsilon)
-                    y0  -= dY
-                    iter+=1
+        def NewtonOptimisationLat(f, y0, x, a, Y, u1, v1, u2, v2, speed_s, speed_e, R, λ, θ, ψ):
+            tryNum = 1
+            iter = 0
+            improving = True
+            while improving:
+                F, dF, X1, X2 = f(y0, x, a, Y, u1, v1, u2, v2, speed_s, speed_e, R, λ, θ, ψ)
+                if (F == 0) or (dF == 0):
+                    dY = 0
+                else:
+                    dY = (F / dF)
+                improving = abs(dY) > 1 or (abs(dY) > self._epsilon * (X1 * X2) and (abs(dY) / iter) > self._epsilon)
+                y0 -= dY
+                iter += 1
 
-                    if (iter>100 and tryNum == 1):
-                        y0 = Y*x/(x+a)
-                        tryNum+=1
-                    if (iter > 200) and tryNum== 2:
-                        tryNum+=1
-                        if(Y < 0):
-                            if v2>v1:
-                                y0 = Y
-                            else:
-                                y0 = 0
+                if (iter > 100 and tryNum == 1):
+                    y0 = Y * x / (x + a)
+                    tryNum += 1
+                if (iter > 200) and tryNum == 2:
+                    tryNum += 1
+                    if(Y < 0):
+                        if v2 > v1:
+                            y0 = Y
                         else:
-                            if (v2<v1):
-                                y0 = Y
-                            else:
-                                y0 = 0
-                    if iter > 1000:
-                        raise Exception('Newton Curve Issue')
-                return y0
+                            y0 = 0
+                    else:
+                        if (v2 < v1):
+                            y0 = Y
+                        else:
+                            y0 = 0
+                if iter > 1000:
+                    raise Exception('Newton Curve Issue')
+            return y0
 
-        def _F(y,x,a,Y,u1,v1,u2,v2,speed_s,speed_e,R,λ,θ,ψ):
-            λ   = λ*(np.pi/180)
-            ψ   = ψ*(np.pi/180)
-            θ   = θ*(np.pi/180)
-            r1  = np.cos(λ)/np.cos(θ)
-            r2  = np.cos(ψ)/np.cos(θ)
+        def _F(y, x, a, Y, u1, v1, u2, v2, speed_s, speed_e, R, λ, θ, ψ):
+            λ = λ * (np.pi / 180)
+            ψ = ψ * (np.pi / 180)
+            θ = θ * (np.pi / 180)
+            r1 = np.cos(λ) / np.cos(θ)
+            r2 = np.cos(ψ) / np.cos(θ)
 
-            d1  = np.sqrt(x**2 + (r1*y)**2)
-            d2  = np.sqrt(a**2 + (r2*(Y-y))**2)
-            C1  = speed_s**2 - u1**2 - v1**2
-            C2  = speed_e**2 - u2**2 - v2**2
-            D1  = x*u1 + r1*v1*y
-            D2  = a*u2 + r2*v2*(Y-y)
-            X1  = np.sqrt(D1**2 + C1*(d1**2))
-            X2  = np.sqrt(D2**2 + C2*(d2**2)) 
+            d1 = np.sqrt(x**2 + (r1 * y)**2)
+            d2 = np.sqrt(a**2 + (r2 * (Y - y))**2)
+            C1 = speed_s**2 - u1**2 - v1**2
+            C2 = speed_e**2 - u2**2 - v2**2
+            D1 = x * u1 + r1 * v1 * y
+            D2 = a * u2 + r2 * v2 * (Y - y)
+            X1 = np.sqrt(D1**2 + C1 * (d1**2))
+            X2 = np.sqrt(D2**2 + C2 * (d2**2))
 
-            dX1 = (r1*(D1*v1 + r1*C1*y))/X1
+            dX1 = (r1 * (D1 * v1 + r1 * C1 * y)) / X1
 
             # Cassing Warning message - FIX !!
-            dX2 = (-r2*(D2*v2 + r2*C2*(Y-y)))/X2
+            dX2 = (-r2 * (D2 * v2 + r2 * C2 * (Y - y))) / X2
 
-            F = ((r2**2)*X1+(r1**2)*X2)*y - r1*v1*(X1-D1)*X2/C1 - r2*(r2*Y-v2*(X2-D2)/C2)*X1
+            F = ((r2**2) * X1 + (r1**2) * X2) * y - r1 * v1 * (X1 - D1) * X2 / C1 - r2 * (r2 * Y - v2 * (X2 - D2) / C2) * X1
 
-            dF = ((r2**2)*X1 + (r1**2)*X2) + y*((r2**2)*dX1 + (r1**2)*dX2)\
-                - r1*v1*((X1-D1)*dX2 + (dX1-r1*v1)*X2)/C1\
-                - (r2**2)*Y*dX1\
-                + r2*v2*((X2-D2)*dX1 + (dX2+r2*v2)*X1)/C2
+            dF = ((r2**2) * X1 + (r1**2) * X2) + y * ((r2**2) * dX1 + (r1**2) * dX2)\
+                - r1 * v1 * ((X1 - D1) * dX2 + (dX1 - r1 * v1) * X2) / C1\
+                - (r2**2) * Y * dX1\
+                + r2 * v2 * ((X2 - D2) * dX1 + (dX2 + r2 * v2) * X1) / C2
 
-            return F,dF,X1,X2
+            return F, dF, X1, X2
 
+        Sp = tuple(self.triplet.iloc[0][['cx', 'cy']])
+        Cp = tuple(self.triplet.iloc[1][['cx', 'cy']])
+        Np = tuple(self.triplet.iloc[2][['cx', 'cy']])
 
-        Sp = tuple(self.triplet.iloc[0][['cx','cy']])
-        Cp = tuple(self.triplet.iloc[1][['cx','cy']])
-        Np = tuple(self.triplet.iloc[2][['cx','cy']])
+        cell_s_u = self.neighbour_graph.loc[self.triplet.iloc[1]['cellStart'].name, 'Vector_x']
+        cell_s_v = self.neighbour_graph.loc[self.triplet.iloc[1]['cellStart'].name, 'Vector_y']
+        cell_e_u = self.neighbour_graph.loc[self.triplet.iloc[1]['cellEnd'].name, 'Vector_x']
+        cell_e_v = self.neighbour_graph.loc[self.triplet.iloc[1]['cellEnd'].name, 'Vector_y']
 
-        cell_s_u = self.neighbour_graph.loc[self.triplet.iloc[1]['cellStart'].name,'Vector_x']
-        cell_s_v = self.neighbour_graph.loc[self.triplet.iloc[1]['cellStart'].name,'Vector_y']
-        cell_e_u = self.neighbour_graph.loc[self.triplet.iloc[1]['cellEnd'].name,'Vector_x']
-        cell_e_v = self.neighbour_graph.loc[self.triplet.iloc[1]['cellEnd'].name,'Vector_y']
-
-        if self.triplet.iloc[1].case == 4:   
-            sgn   = 1
+        if self.triplet.iloc[1].case == 4:
+            sgn = 1
         else:
-            sgn   = -1
+            sgn = -1
 
-        λ=Sp[1]
-        θ=Cp[1]   
-        ψ=Np[1]  
+        λ = Sp[1]
+        θ = Cp[1]
+        ψ = Np[1]
 
-        x     = sgn*self._calYDist(Sp[1],Cp[1])
-        a     = sgn*self._calYDist(Cp[1],Np[1])
-        Y     = sgn*(Np[0]-Sp[0])*self.m_long*np.cos(Cp[1]*(np.pi/180))
-        Su    = -sgn*self.zc*cell_s_v; Sv = sgn*self.zc*cell_s_u
-        Nu    = -sgn*self.zc*cell_e_v; Nv = sgn*self.zc*cell_e_u
-        y0    = Y/2
+        x = sgn * self._calYDist(Sp[1], Cp[1])
+        a = sgn * self._calYDist(Cp[1], Np[1])
+        Y = sgn * (Np[0] - Sp[0]) * self.m_long * np.cos(Cp[1] * (np.pi / 180))
+        Su = -sgn * self.zc * cell_s_v
+        Sv = sgn * self.zc * cell_s_u
+        Nu = -sgn * self.zc * cell_e_v
+        Nv = sgn * self.zc * cell_e_u
+        y0 = Y / 2
 
-        y     = NewtonOptimisationLat(_F,y0,x,a,Y,Su,Sv,Nu,Nv,self.speed_s,self.speed_e,self.R,λ,θ,ψ)
+        y = NewtonOptimisationLat(_F, y0, x, a, Y, Su, Sv, Nu, Nv, self.speed_s, self.speed_e, self.R, λ, θ, ψ)
 
-        self.triplet['cx'].iloc[1] = Sp[0] + sgn*y/(self.m_long*np.cos(Cp[1]*(np.pi/180)))
+        self.triplet['cx'].iloc[1] = Sp[0] + sgn * y / (self.m_long * np.cos(Cp[1] * (np.pi / 180)))
         self.triplet['cy'].iloc[1] = Cp[1]
-
 
     def _corner_case(self):
         '''
             FILL
         '''
         # Separting out the Long/Lat of each of the points
-        Xs,Ys = tuple(self.triplet.iloc[0][['cx','cy']])
-        Xc,Yc = tuple(self.triplet.iloc[1][['cx','cy']])
-        Xe,Ye = tuple(self.triplet.iloc[2][['cx','cy']])
+        Xs, Ys = tuple(self.triplet.iloc[0][['cx', 'cy']])
+        Xc, Yc = tuple(self.triplet.iloc[1][['cx', 'cy']])
+        Xe, Ye = tuple(self.triplet.iloc[2][['cx', 'cy']])
 
         # === 1. Assess the cells that are shared commonly in the corner case ====
         sourceNeighbourIndices = self.triplet.iloc[1]['cellStart']
-        endNeighbourIndices    = self.triplet.iloc[1]['cellEnd']
-    
+        endNeighbourIndices = self.triplet.iloc[1]['cellEnd']
+
         commonIndices = list(set(sourceNeighbourIndices['neighbourIndex']).intersection(endNeighbourIndices['neighbourIndex']))
-        CornerCells   = self.neighbour_graph.loc[commonIndices]
-        Y_line = ((Ye-Ys)/(Xe-Xs))*(Xc-Xs) + Ys
+        CornerCells = self.neighbour_graph.loc[commonIndices]
+        Y_line = ((Ye - Ys) / (Xe - Xs)) * (Xc - Xs) + Ys
 
         try:
             if Yc >= Y_line:
@@ -692,394 +684,371 @@ class NewtonianCurve:
                     return
             # === 3. Return the path crossing points and cell indices
 
-            firstCrossingPoint  = np.array(sourceNeighbourIndices['neighbourCrossingPoints'])[np.where(np.array(sourceNeighbourIndices['neighbourIndex'])==newCell.name)[0][0],:]
-            secondCrossingPoint = np.array(newCell['neighbourCrossingPoints'])[np.where(np.array(newCell['neighbourIndex'])==endNeighbourIndices.name)[0][0],:]
+            firstCrossingPoint = np.array(sourceNeighbourIndices['neighbourCrossingPoints'])[np.where(np.array(sourceNeighbourIndices['neighbourIndex']) == newCell.name)[0][0], :]
+            secondCrossingPoint = np.array(newCell['neighbourCrossingPoints'])[np.where(np.array(newCell['neighbourIndex']) == endNeighbourIndices.name)[0][0], :]
         except:
             self.triplet = copy.deepcopy(self.org_triplet)
             return
 
         # Adding in the new crossing Point
-        newP = pd.Series(name=self.triplet.iloc[1].name+1,dtype='object')
-        newP['cx']        = secondCrossingPoint[0]
-        newP['cy']        = secondCrossingPoint[1]
+        newP = pd.Series(name=self.triplet.iloc[1].name + 1, dtype='object')
+        newP['cx'] = secondCrossingPoint[0]
+        newP['cy'] = secondCrossingPoint[1]
         newP['cellStart'] = newCell
-        newP['cellEnd']   = copy.deepcopy(self.triplet['cellEnd'].iloc[1])
-        newP['case']      = newP['cellStart']['case'][np.where(np.array(newP['cellStart']['neighbourIndex'])==newP['cellEnd'].name)[0][0]]
-
+        newP['cellEnd'] = copy.deepcopy(self.triplet['cellEnd'].iloc[1])
+        newP['case'] = newP['cellStart']['case'][np.where(np.array(newP['cellStart']['neighbourIndex']) == newP['cellEnd'].name)[0][0]]
 
         # Updating the origional crossing point
-        self.triplet['cx'].iloc[1]      = firstCrossingPoint[0]
-        self.triplet['cy'].iloc[1]      = firstCrossingPoint[1]
-        self.triplet['cellEnd'].iloc[1] = newCell 
-        self.triplet['case'].iloc[1]    = self.triplet['cellStart'].iloc[1]['case'][np.where(np.array(self.triplet['cellStart'].iloc[1]['neighbourIndex'])==newCell.name)[0][0]]
-
+        self.triplet['cx'].iloc[1] = firstCrossingPoint[0]
+        self.triplet['cy'].iloc[1] = firstCrossingPoint[1]
+        self.triplet['cellEnd'].iloc[1] = newCell
+        self.triplet['case'].iloc[1] = self.triplet['cellStart'].iloc[1]['case'][np.where(np.array(self.triplet['cellStart'].iloc[1]['neighbourIndex']) == newCell.name)[0][0]]
 
         # Adding the new crossing point to the triplet
         self.newP = newP
 
-        self.CrossingDF = pd.concat([self.CrossingDF,newP.to_frame().transpose()]).sort_index().reset_index(drop=True) #self.CrossingDF.append(newP,sort=True).sort_index().reset_index(drop=True)
-        self.CrossingDF.index = np.arange(int(self.CrossingDF.index.min()),int(self.CrossingDF.index.max()*1e3 + 1e3),int(1e3))
-
+        self.CrossingDF = pd.concat([self.CrossingDF, newP.to_frame().transpose()]).sort_index().reset_index(drop=True)  # self.CrossingDF.append(newP,sort=True).sort_index().reset_index(drop=True)
+        self.CrossingDF.index = np.arange(int(self.CrossingDF.index.min()), int(self.CrossingDF.index.max() * 1e3 + 1e3), int(1e3))
 
     def _mergePoint(self):
         '''
             FILL
         '''
-        def PtDist(Ser1,Ser2):
-            #return np.sqrt(self._calXDist(Ser2['cx'],Ser1['cx'])**2 + self._calXDist(Ser2['cy'],Ser1['cy'])**2)
+        def PtDist(Ser1, Ser2):
+            # return np.sqrt(self._calXDist(Ser2['cx'],Ser1['cx'])**2 + self._calXDist(Ser2['cy'],Ser1['cy'])**2)
             return np.sqrt((Ser1['cx'] - Ser2['cx'])**2 + (Ser1['cy'] - Ser2['cy'])**2)
 
-        id=0
-        while id < len(self.CrossingDF)-3:
-            triplet = self.CrossingDF.iloc[id:id+3]
-            if PtDist(triplet.iloc[0],triplet.iloc[1]) < 2e-3:
+        id = 0
+        while id < len(self.CrossingDF) - 3:
+            triplet = self.CrossingDF.iloc[id:id + 3]
+            if PtDist(triplet.iloc[0], triplet.iloc[1]) < 2e-3:
                 try:
-                    neighbourIndex = np.where(np.array(triplet.iloc[0]['cellStart']['neighbourIndex'])==triplet.iloc[1]['cellEnd'].name)[0][0]
+                    neighbourIndex = np.where(np.array(triplet.iloc[0]['cellStart']['neighbourIndex']) == triplet.iloc[1]['cellEnd'].name)[0][0]
                 except:
-                    id+=1
+                    id += 1
                     continue
-                case           = triplet['cellStart'].iloc[0]['case'][neighbourIndex]
-                crossingPoint  = triplet['cellStart'].iloc[0]['neighbourCrossingPoints'][neighbourIndex]
-                triplet['cx'].iloc[0]      = crossingPoint[0]
-                triplet['cy'].iloc[0]      = crossingPoint[1]
+                case = triplet['cellStart'].iloc[0]['case'][neighbourIndex]
+                crossingPoint = triplet['cellStart'].iloc[0]['neighbourCrossingPoints'][neighbourIndex]
+                triplet['cx'].iloc[0] = crossingPoint[0]
+                triplet['cy'].iloc[0] = crossingPoint[1]
                 triplet['cellEnd'].iloc[0] = copy.deepcopy(triplet.iloc[1]['cellEnd'])
-                triplet['case'].iloc[0]    = copy.deepcopy(case)
-                self.CrossingDF           = self.CrossingDF.drop(triplet.iloc[1].name)
-            if PtDist(triplet.iloc[1],triplet.iloc[2]) < 2e-3:
+                triplet['case'].iloc[0] = copy.deepcopy(case)
+                self.CrossingDF = self.CrossingDF.drop(triplet.iloc[1].name)
+            if PtDist(triplet.iloc[1], triplet.iloc[2]) < 2e-3:
                 try:
-                    neighbourIndex = np.where(np.array(triplet.iloc[1]['cellStart']['neighbourIndex'])==triplet.iloc[2]['cellEnd'].name)[0][0]
+                    neighbourIndex = np.where(np.array(triplet.iloc[1]['cellStart']['neighbourIndex']) == triplet.iloc[2]['cellEnd'].name)[0][0]
                 except:
-                    id+=1
+                    id += 1
                     continue
-                case           = triplet['cellStart'].iloc[1]['case'][neighbourIndex]
-                crossingPoint  = triplet['cellStart'].iloc[1]['neighbourCrossingPoints'][neighbourIndex]
-                triplet['cx'].iloc[1]      = crossingPoint[0]
-                triplet['cy'].iloc[1]      = crossingPoint[1]
+                case = triplet['cellStart'].iloc[1]['case'][neighbourIndex]
+                crossingPoint = triplet['cellStart'].iloc[1]['neighbourCrossingPoints'][neighbourIndex]
+                triplet['cx'].iloc[1] = crossingPoint[0]
+                triplet['cy'].iloc[1] = crossingPoint[1]
                 triplet['cellEnd'].iloc[1] = copy.deepcopy(triplet.iloc[2]['cellEnd'])
-                triplet['case'].iloc[1]    = copy.deepcopy(case)
-                self.CrossingDF           = self.CrossingDF.drop(triplet.iloc[2].name)
+                triplet['case'].iloc[1] = copy.deepcopy(case)
+                self.CrossingDF = self.CrossingDF.drop(triplet.iloc[2].name)
 
-            id+=1
+            id += 1
 
         self.CrossingDF = self.CrossingDF.sort_index().reset_index(drop=True)
-        self.CrossingDF.index = np.arange(int(self.CrossingDF.index.min()),int(self.CrossingDF.index.max()*1e3 + 1e3),int(1e3))
-
-
+        self.CrossingDF.index = np.arange(int(self.CrossingDF.index.min()), int(self.CrossingDF.index.max() * 1e3 + 1e3), int(1e3))
 
     def _horseshoe(self):
         '''
             FILL
         '''
         # Defining the case information
-        Cp             = tuple(self.triplet[['cx','cy']].iloc[1])
-        Sp             = tuple(self.triplet.iloc[0][['cx','cy']])
-        Np             = tuple(self.triplet.iloc[2][['cx','cy']])
-        
+        Cp = tuple(self.triplet[['cx', 'cy']].iloc[1])
+        Sp = tuple(self.triplet.iloc[0][['cx', 'cy']])
+        Np = tuple(self.triplet.iloc[2][['cx', 'cy']])
+
         cellStartGraph = self.triplet.iloc[1]['cellStart']
-        cellEndGraph   = self.triplet.iloc[1]['cellEnd']        
-        case           = self.triplet['case'].iloc[1]
+        cellEndGraph = self.triplet.iloc[1]['cellEnd']
+        case = self.triplet['case'].iloc[1]
 
         # Returning if corner horseshoe case type
-        if abs(case)==1 or abs(case)==3 or abs(case)==0: 
+        if abs(case) == 1 or abs(case) == 3 or abs(case) == 0:
             return
         elif abs(case) == 2:
             # Defining the min and max of the start and end cells
-            smin = cellStartGraph['cy']-cellStartGraph['dcy'] 
-            smax = cellStartGraph['cy']+cellStartGraph['dcy']
-            emin = cellEndGraph['cy']-cellEndGraph['dcy']
-            emax = cellEndGraph['cy']+cellEndGraph['dcy']
+            smin = cellStartGraph['cy'] - cellStartGraph['dcy']
+            smax = cellStartGraph['cy'] + cellStartGraph['dcy']
+            emin = cellEndGraph['cy'] - cellEndGraph['dcy']
+            emax = cellEndGraph['cy'] + cellEndGraph['dcy']
 
             # Defining the global min and max
-            vmin = np.max([smin,emin])
-            vmax = np.min([smax,emax])
+            vmin = np.max([smin, emin])
+            vmax = np.min([smax, emax])
 
             # Point crossingpoint on boundary between the two origional cells
             if (Cp[1] > vmin) and (Cp[1] < vmax):
                 return
 
-            # If Start and end cells share a edge for the horesshoe 
-            if (Cp[1]<=smin) and (smin==emin):
+            # If Start and end cells share a edge for the horesshoe
+            if (Cp[1] <= smin) and (smin == emin):
                 hrshCaseStart = 4
-                hrshCaseEnd   = 4
-            if (Cp[1]>=smax) and (smax==emax):
+                hrshCaseEnd = 4
+            if (Cp[1] >= smax) and (smax == emax):
                 hrshCaseStart = -4
-                hrshCaseEnd   = -4
+                hrshCaseEnd = -4
 
             # --- Cases where StartCell is Larger than end Cell ---
-            if (Cp[1]>=emax) and (smax>emax):
+            if (Cp[1] >= emax) and (smax > emax):
                 hrshCaseStart = case
-                hrshCaseEnd   = (-4)                
-            if (Cp[1]<=emin) and (smin<emin):
+                hrshCaseEnd = (-4)
+            if (Cp[1] <= emin) and (smin < emin):
                 hrshCaseStart = case
-                hrshCaseEnd   = (4)                   
+                hrshCaseEnd = (4)
 
             # --- Cases where StartCell is smaller than end Cell ---
-            if (Cp[1]>=smax) and (smax<emax):
+            if (Cp[1] >= smax) and (smax < emax):
                 hrshCaseStart = -4
-                hrshCaseEnd   = -case
-            if (Cp[1]<=smin) and (emin<smin):
+                hrshCaseEnd = -case
+            if (Cp[1] <= smin) and (emin < smin):
                 hrshCaseStart = 4
-                hrshCaseEnd   = -case                    
+                hrshCaseEnd = -case
 
         elif abs(case) == 4:
             # Defining the min and max of the start and end cells
-            smin = cellStartGraph['cx']-cellStartGraph['dcx']
-            smax = cellStartGraph['cx']+cellStartGraph['dcx']
-            emin = cellEndGraph['cx']-cellEndGraph['dcx']
-            emax = cellEndGraph['cx']+cellEndGraph['dcx']
+            smin = cellStartGraph['cx'] - cellStartGraph['dcx']
+            smax = cellStartGraph['cx'] + cellStartGraph['dcx']
+            emin = cellEndGraph['cx'] - cellEndGraph['dcx']
+            emax = cellEndGraph['cx'] + cellEndGraph['dcx']
 
             # Defining the global min and max
-            vmin = np.max([smin,emin])
-            vmax = np.min([smax,emax])
+            vmin = np.max([smin, emin])
+            vmax = np.min([smax, emax])
 
             # Point crossingpoint on boundary between the two origional cells
             if (Cp[0] >= vmin) and (Cp[0] <= vmax):
                 return
 
-            # If Start and end cells share a edge for the horesshoe 
-            if (Cp[0]<smin) and (smin==emin):
+            # If Start and end cells share a edge for the horesshoe
+            if (Cp[0] < smin) and (smin == emin):
                 hrshCaseStart = -2
-                hrshCaseEnd   = -2
-            if (Cp[0]>smax) and (smax==emax):
+                hrshCaseEnd = -2
+            if (Cp[0] > smax) and (smax == emax):
                 hrshCaseStart = 2
-                hrshCaseEnd   = 2
+                hrshCaseEnd = 2
 
             # --- Cases where StartCell is Larger than end Cell ---
-            if (Cp[0]>emax) and (smax>emax):
+            if (Cp[0] > emax) and (smax > emax):
                 hrshCaseStart = case
-                hrshCaseEnd   = (2)                
-            if (Cp[0]<emin) and (smin<emin):
+                hrshCaseEnd = (2)
+            if (Cp[0] < emin) and (smin < emin):
                 hrshCaseStart = case
-                hrshCaseEnd   = (-2)                   
+                hrshCaseEnd = (-2)
 
             # --- Cases where StartCell is smaller than end Cell ---
-            if (Cp[0]>smax) and (smax<emax):
+            if (Cp[0] > smax) and (smax < emax):
                 hrshCaseStart = (2)
-                hrshCaseEnd   = -case
-            if (Cp[0]<smin) and (emin<smin):
+                hrshCaseEnd = -case
+            if (Cp[0] < smin) and (emin < smin):
                 hrshCaseStart = (-2)
-                hrshCaseEnd   = -case   
-
+                hrshCaseEnd = -case
 
         # Determining the neighbours of the start and end cells that are the horseshoe case
-        startGraphNeighbours = [cellStartGraph['neighbourIndex'][ii] for ii in list(np.where(np.array(cellStartGraph['case'])==hrshCaseStart)[0])]
-        endGraphNeighbours   = [cellEndGraph['neighbourIndex'][ii] for ii in list(np.where(np.array(cellEndGraph['case'])==hrshCaseEnd)[0])]
+        startGraphNeighbours = [cellStartGraph['neighbourIndex'][ii] for ii in list(np.where(np.array(cellStartGraph['case']) == hrshCaseStart)[0])]
+        endGraphNeighbours = [cellEndGraph['neighbourIndex'][ii] for ii in list(np.where(np.array(cellEndGraph['case']) == hrshCaseEnd)[0])]
 
         # If there is no neighbour trim back to the edge of the cell
-        if (len(startGraphNeighbours)==0) or (len(endGraphNeighbours)==0):
+        if (len(startGraphNeighbours) == 0) or (len(endGraphNeighbours) == 0):
             if abs(case) == 2:
-                self.triplet['cy'].iloc[1] = np.clip(self.triplet.iloc[1]['cy'],vmin,vmax)
+                self.triplet['cy'].iloc[1] = np.clip(self.triplet.iloc[1]['cy'], vmin, vmax)
             if abs(case) == 4:
-                self.triplet['cx'].iloc[1] = np.clip(self.triplet.iloc[1]['cx'],vmin,vmax)        
+                self.triplet['cx'].iloc[1] = np.clip(self.triplet.iloc[1]['cx'], vmin, vmax)
             return
 
-        
         if abs(hrshCaseStart) == abs(hrshCaseEnd):
             for sGN in startGraphNeighbours:
                 for eGN in endGraphNeighbours:
-                    if (np.array(self.neighbour_graph.loc[sGN,'neighbourIndex'])==eGN).any() and (np.array(self.neighbour_graph.loc[eGN,'neighbourIndex'])==sGN).any():
+                    if (np.array(self.neighbour_graph.loc[sGN, 'neighbourIndex']) == eGN).any() and (np.array(self.neighbour_graph.loc[eGN, 'neighbourIndex']) == sGN).any():
                         sGNGraph = self.neighbour_graph.loc[sGN]
                         eGNGraph = self.neighbour_graph.loc[eGN]
 
-
                         try:
 
-                            Crp1 = np.array(cellStartGraph['neighbourCrossingPoints'])[np.where(np.array(cellStartGraph['neighbourIndex']) == sGN)[0][0],:]
-                            Crp2 = np.array(sGNGraph['neighbourCrossingPoints'])[np.where(np.array(sGNGraph['neighbourIndex']) == eGN)[0][0],:]
-                            Crp3 = np.array(eGNGraph['neighbourCrossingPoints'])[np.where(np.array(eGNGraph['neighbourIndex']) == cellEndGraph.name)[0][0],:]
-                        
+                            Crp1 = np.array(cellStartGraph['neighbourCrossingPoints'])[np.where(np.array(cellStartGraph['neighbourIndex']) == sGN)[0][0], :]
+                            Crp2 = np.array(sGNGraph['neighbourCrossingPoints'])[np.where(np.array(sGNGraph['neighbourIndex']) == eGN)[0][0], :]
+                            Crp3 = np.array(eGNGraph['neighbourCrossingPoints'])[np.where(np.array(eGNGraph['neighbourIndex']) == cellEndGraph.name)[0][0], :]
+
                         except:
                             if abs(case) == 2:
-                                self.triplet['cy'].iloc[1] = np.clip(self.triplet.iloc[1]['cy'],vmin,vmax)
+                                self.triplet['cy'].iloc[1] = np.clip(self.triplet.iloc[1]['cy'], vmin, vmax)
                             if abs(case) == 4:
-                                self.triplet['cx'].iloc[1] = np.clip(self.triplet.iloc[1]['cx'],vmin,vmax)        
+                                self.triplet['cx'].iloc[1] = np.clip(self.triplet.iloc[1]['cx'], vmin, vmax)
                             return
 
                         # Trimminng back if the cell is worse off
-                        if ('SIC' in sGNGraph) and ('SIC' in cellStartGraph) and (sGNGraph['SIC'] - cellStartGraph['SIC'])>=2:
+                        if ('SIC' in sGNGraph) and ('SIC' in cellStartGraph) and (sGNGraph['SIC'] - cellStartGraph['SIC']) >= 2:
                             if abs(case) == 2:
-                                self.triplet['cy'].iloc[1] = np.clip(self.triplet.iloc[1]['cy'],vmin,vmax)
+                                self.triplet['cy'].iloc[1] = np.clip(self.triplet.iloc[1]['cy'], vmin, vmax)
                             if abs(case) == 4:
-                                self.triplet['cx'].iloc[1] = np.clip(self.triplet.iloc[1]['cx'],vmin,vmax)        
+                                self.triplet['cx'].iloc[1] = np.clip(self.triplet.iloc[1]['cx'], vmin, vmax)
                             return
-
 
                         # Trimminng back if the cell is worse off fuel
-                        if ('fuel' in sGNGraph) and ('fuel' in cellStartGraph) and (sGNGraph['fuel'] - cellStartGraph['fuel'])>=2:
+                        if ('fuel' in sGNGraph) and ('fuel' in cellStartGraph) and (sGNGraph['fuel'] - cellStartGraph['fuel']) >= 2:
                             if abs(case) == 2:
-                                self.triplet['cy'].iloc[1] = np.clip(self.triplet.iloc[1]['cy'],vmin,vmax)
+                                self.triplet['cy'].iloc[1] = np.clip(self.triplet.iloc[1]['cy'], vmin, vmax)
                             if abs(case) == 4:
-                                self.triplet['cx'].iloc[1] = np.clip(self.triplet.iloc[1]['cx'],vmin,vmax)        
+                                self.triplet['cx'].iloc[1] = np.clip(self.triplet.iloc[1]['cx'], vmin, vmax)
                             return
 
-
                         # Updating the origional crossing point
-                        self.triplet['cx'].iloc[1]      = Crp1[0]
-                        self.triplet['cy'].iloc[1]      = Crp1[1]
+                        self.triplet['cx'].iloc[1] = Crp1[0]
+                        self.triplet['cy'].iloc[1] = Crp1[1]
                         self.triplet['cellEnd'].iloc[1] = copy.deepcopy(sGNGraph)
-                        self.triplet['case'].iloc[1]    = self.triplet['cellStart'].iloc[1]['case'][np.where(np.array(self.triplet['cellStart'].iloc[1]['neighbourIndex'])==sGNGraph.name)[0][0]]
+                        self.triplet['case'].iloc[1] = self.triplet['cellStart'].iloc[1]['case'][np.where(np.array(self.triplet['cellStart'].iloc[1]['neighbourIndex']) == sGNGraph.name)[0][0]]
 
                         # Crossing Point 2
-                        Pcrp2 = pd.Series(name=self.triplet.iloc[1].name+1,dtype='object')
-                        Pcrp2['cx']        = Crp2[0]
-                        Pcrp2['cy']        = Crp2[1]
+                        Pcrp2 = pd.Series(name=self.triplet.iloc[1].name + 1, dtype='object')
+                        Pcrp2['cx'] = Crp2[0]
+                        Pcrp2['cy'] = Crp2[1]
                         Pcrp2['cellStart'] = copy.deepcopy(sGNGraph)
-                        Pcrp2['cellEnd']   = copy.deepcopy(eGNGraph)
-                        Pcrp2['case']      = Pcrp2['cellStart']['case'][np.where(np.array(Pcrp2['cellStart']['neighbourIndex'])==Pcrp2['cellEnd'].name)[0][0]]
+                        Pcrp2['cellEnd'] = copy.deepcopy(eGNGraph)
+                        Pcrp2['case'] = Pcrp2['cellStart']['case'][np.where(np.array(Pcrp2['cellStart']['neighbourIndex']) == Pcrp2['cellEnd'].name)[0][0]]
 
-                        Pcrp3 = pd.Series(name=self.triplet.iloc[1].name+2,dtype='object')
-                        Pcrp3['cx']        = Crp3[0]
-                        Pcrp3['cy']        = Crp3[1]
+                        Pcrp3 = pd.Series(name=self.triplet.iloc[1].name + 2, dtype='object')
+                        Pcrp3['cx'] = Crp3[0]
+                        Pcrp3['cy'] = Crp3[1]
                         Pcrp3['cellStart'] = copy.deepcopy(eGNGraph)
-                        Pcrp3['cellEnd']   = copy.deepcopy(cellEndGraph)
-                        Pcrp3['case']      = Pcrp3['cellStart']['case'][np.where(np.array(Pcrp3['cellStart']['neighbourIndex'])==Pcrp3['cellEnd'].name)[0][0]]
-                        
+                        Pcrp3['cellEnd'] = copy.deepcopy(cellEndGraph)
+                        Pcrp3['case'] = Pcrp3['cellStart']['case'][np.where(np.array(Pcrp3['cellStart']['neighbourIndex']) == Pcrp3['cellEnd'].name)[0][0]]
 
-                        self.CrossingDF = pd.concat([self.CrossingDF,Pcrp2.to_frame().transpose(),Pcrp3.to_frame().transpose()], sort=True).sort_index().reset_index(drop=True) #self.CrossingDF.append([Pcrp2,Pcrp3],sort=True).sort_index().reset_index(drop=True)
+                        self.CrossingDF = pd.concat([self.CrossingDF, Pcrp2.to_frame().transpose(), Pcrp3.to_frame().transpose()], sort=True).sort_index().reset_index(drop=True)  # self.CrossingDF.append([Pcrp2,Pcrp3],sort=True).sort_index().reset_index(drop=True)
 
-                        self.CrossingDF.index = np.arange(int(self.CrossingDF.index.min()),int(self.CrossingDF.index.max()*1e3 + 1e3),int(1e3))
+                        self.CrossingDF.index = np.arange(int(self.CrossingDF.index.min()), int(self.CrossingDF.index.max() * 1e3 + 1e3), int(1e3))
 
                         break
 
             if abs(case) == 2:
-                self.triplet['cy'].iloc[1] = np.clip(self.triplet.iloc[1]['cy'],vmin,vmax)
+                self.triplet['cy'].iloc[1] = np.clip(self.triplet.iloc[1]['cy'], vmin, vmax)
             if abs(case) == 4:
-                self.triplet['cx'].iloc[1] = np.clip(self.triplet.iloc[1]['cx'],vmin,vmax)        
+                self.triplet['cx'].iloc[1] = np.clip(self.triplet.iloc[1]['cx'], vmin, vmax)
             return
         else:
             for sGN in startGraphNeighbours:
                 for eGN in endGraphNeighbours:
-                    if (np.array(sGN==eGN).any()):
-                        
-                        NeighGraph = self.neighbour_graph.loc[sGN]            
-                        
-                        
+                    if (np.array(sGN == eGN).any()):
+
+                        NeighGraph = self.neighbour_graph.loc[sGN]
+
                         try:
-                            Crp1 = np.array(cellStartGraph['neighbourCrossingPoints'])[np.where(np.array(cellStartGraph['neighbourIndex']) == sGN)[0][0],:]
-                            Crp2 = np.array(NeighGraph['neighbourCrossingPoints'])[np.where(np.array(NeighGraph['neighbourIndex']) == cellEndGraph.name)[0][0],:]
+                            Crp1 = np.array(cellStartGraph['neighbourCrossingPoints'])[np.where(np.array(cellStartGraph['neighbourIndex']) == sGN)[0][0], :]
+                            Crp2 = np.array(NeighGraph['neighbourCrossingPoints'])[np.where(np.array(NeighGraph['neighbourIndex']) == cellEndGraph.name)[0][0], :]
 
                         except:
                             if abs(case) == 2:
-                                self.triplet['cy'].iloc[1] = np.clip(self.triplet.iloc[1]['cy'],vmin,vmax)
+                                self.triplet['cy'].iloc[1] = np.clip(self.triplet.iloc[1]['cy'], vmin, vmax)
                             if abs(case) == 4:
-                                self.triplet['cx'].iloc[1] = np.clip(self.triplet.iloc[1]['cx'],vmin,vmax)        
+                                self.triplet['cx'].iloc[1] = np.clip(self.triplet.iloc[1]['cx'], vmin, vmax)
                             return
 
-
                         # Trimminng back if the cell is worse off
-                        if ('SIC' in NeighGraph) and ('SIC' in cellStartGraph) and (NeighGraph['SIC'] - cellStartGraph['SIC'])>=2:
+                        if ('SIC' in NeighGraph) and ('SIC' in cellStartGraph) and (NeighGraph['SIC'] - cellStartGraph['SIC']) >= 2:
                             if abs(case) == 2:
-                                self.triplet['cy'].iloc[1] = np.clip(self.triplet.iloc[1]['cy'],vmin,vmax)
+                                self.triplet['cy'].iloc[1] = np.clip(self.triplet.iloc[1]['cy'], vmin, vmax)
                             if abs(case) == 4:
-                                self.triplet['cx'].iloc[1] = np.clip(self.triplet.iloc[1]['cx'],vmin,vmax)        
+                                self.triplet['cx'].iloc[1] = np.clip(self.triplet.iloc[1]['cx'], vmin, vmax)
                             return
 
                         # Trimminng back if the cell is worse off fuel
-                        if ('fuel' in NeighGraph) and ('fuel' in cellStartGraph) and (NeighGraph['fuel'] - cellStartGraph['fuel'])>=2:
+                        if ('fuel' in NeighGraph) and ('fuel' in cellStartGraph) and (NeighGraph['fuel'] - cellStartGraph['fuel']) >= 2:
                             if abs(case) == 2:
-                                self.triplet['cy'].iloc[1] = np.clip(self.triplet.iloc[1]['cy'],vmin,vmax)
+                                self.triplet['cy'].iloc[1] = np.clip(self.triplet.iloc[1]['cy'], vmin, vmax)
                             if abs(case) == 4:
-                                self.triplet['cx'].iloc[1] = np.clip(self.triplet.iloc[1]['cx'],vmin,vmax)        
+                                self.triplet['cx'].iloc[1] = np.clip(self.triplet.iloc[1]['cx'], vmin, vmax)
                             return
 
-
-
                         # Updating the origional crossing point
-                        self.triplet['cx'].iloc[1]      = Crp1[0]
-                        self.triplet['cy'].iloc[1]      = Crp1[1]
+                        self.triplet['cx'].iloc[1] = Crp1[0]
+                        self.triplet['cy'].iloc[1] = Crp1[1]
                         self.triplet['cellEnd'].iloc[1] = copy.deepcopy(NeighGraph)
-                        self.triplet['case'].iloc[1]    = self.triplet['cellStart'].iloc[1]['case'][np.where(np.array(self.triplet['cellStart'].iloc[1]['neighbourIndex'])==NeighGraph.name)[0][0]]
+                        self.triplet['case'].iloc[1] = self.triplet['cellStart'].iloc[1]['case'][np.where(np.array(self.triplet['cellStart'].iloc[1]['neighbourIndex']) == NeighGraph.name)[0][0]]
 
-                        Pcrp2 = pd.Series(name=self.triplet.iloc[1].name+2,dtype='object')
-                        Pcrp2['cx']        = Crp2[0]
-                        Pcrp2['cy']        = Crp2[1]
+                        Pcrp2 = pd.Series(name=self.triplet.iloc[1].name + 2, dtype='object')
+                        Pcrp2['cx'] = Crp2[0]
+                        Pcrp2['cy'] = Crp2[1]
                         Pcrp2['cellStart'] = copy.deepcopy(NeighGraph)
-                        Pcrp2['cellEnd']   = copy.deepcopy(cellEndGraph)
-                        Pcrp2['case']      = Pcrp2['cellStart']['case'][np.where(np.array(Pcrp2['cellStart']['neighbourIndex'])==Pcrp2['cellEnd'].name)[0][0]]
-                        
-                        self.CrossingDF = pd.concat([self.CrossingDF,Pcrp2.to_frame().transpose()], sort=True).sort_index().reset_index(drop=True)#self.CrossingDF.append([Pcrp2],sort=True).sort_index().reset_index(drop=True)
-                        
-                        self.CrossingDF.index = np.arange(int(self.CrossingDF.index.min()),int(self.CrossingDF.index.max()*1e3 + 1e3),int(1e3))
+                        Pcrp2['cellEnd'] = copy.deepcopy(cellEndGraph)
+                        Pcrp2['case'] = Pcrp2['cellStart']['case'][np.where(np.array(Pcrp2['cellStart']['neighbourIndex']) == Pcrp2['cellEnd'].name)[0][0]]
+
+                        self.CrossingDF = pd.concat([self.CrossingDF, Pcrp2.to_frame().transpose()], sort=True).sort_index().reset_index(drop=True)  # self.CrossingDF.append([Pcrp2],sort=True).sort_index().reset_index(drop=True)
+
+                        self.CrossingDF.index = np.arange(int(self.CrossingDF.index.min()), int(self.CrossingDF.index.max() * 1e3 + 1e3), int(1e3))
 
                         break
 
             if abs(case) == 2:
-                self.triplet['cy'].iloc[1] = np.clip(self.triplet.iloc[1]['cy'],vmin,vmax)
+                self.triplet['cy'].iloc[1] = np.clip(self.triplet.iloc[1]['cy'], vmin, vmax)
             if abs(case) == 4:
-                self.triplet['cx'].iloc[1] = np.clip(self.triplet.iloc[1]['cx'],vmin,vmax)        
+                self.triplet['cx'].iloc[1] = np.clip(self.triplet.iloc[1]['cx'], vmin, vmax)
             return
-                
 
     def _reverseCase(self):
         '''
             FILL
         '''
         # Removing Reverse Edge Type 1
-        startIndex = np.array([row['cellStart'].name for idx,row in self.CrossingDF.iterrows()][1:-1])
-        endIndex   = np.array([row['cellEnd'].name for idx,row in self.CrossingDF.iterrows()][1:-1] )
-        boolReverseEdge  = np.logical_and((startIndex[:-1] == endIndex[1:]),(startIndex[1:] == endIndex[:-1]))
+        startIndex = np.array([row['cellStart'].name for idx, row in self.CrossingDF.iterrows()][1:-1])
+        endIndex = np.array([row['cellEnd'].name for idx, row in self.CrossingDF.iterrows()][1:-1])
+        boolReverseEdge = np.logical_and((startIndex[:-1] == endIndex[1:]), (startIndex[1:] == endIndex[:-1]))
         if boolReverseEdge.any():
-            indxReverseEdge = np.where(boolReverseEdge)[0]+1
+            indxReverseEdge = np.where(boolReverseEdge)[0] + 1
             for id in indxReverseEdge:
                 self.CrossingDF = self.CrossingDF.drop([self.CrossingDF.iloc[id].name]).sort_index().reset_index(drop=True)
 
-
         # Removing Reverse Edge Type 2
-        startIndex = np.array([row['cellStart'].name for idx,row in self.CrossingDF.iterrows()][1:-1])
-        endIndex   = np.array([row['cellEnd'].name for idx,row in self.CrossingDF.iterrows()][1:-1] )
-        boolReverseEdge  = (endIndex[:-1] == endIndex[1:])
+        startIndex = np.array([row['cellStart'].name for idx, row in self.CrossingDF.iterrows()][1:-1])
+        endIndex = np.array([row['cellEnd'].name for idx, row in self.CrossingDF.iterrows()][1:-1])
+        boolReverseEdge = (endIndex[:-1] == endIndex[1:])
         if boolReverseEdge.any():
-            indxReverseEdge = np.where(boolReverseEdge)[0]+2
+            indxReverseEdge = np.where(boolReverseEdge)[0] + 2
             for id in indxReverseEdge:
                 self.CrossingDF = self.CrossingDF.drop(self.CrossingDF.iloc[id].name).sort_index().reset_index(drop=True)
 
         # Removing Reverse Edge Type 3
-        startIndex = np.array([row['cellStart'].name for idx,row in self.CrossingDF.iterrows()][1:-1])
-        endIndex   = np.array([row['cellEnd'].name for idx,row in self.CrossingDF.iterrows()][1:-1] )
-        boolReverseEdge  = (startIndex[:-1] == startIndex[1:])
+        startIndex = np.array([row['cellStart'].name for idx, row in self.CrossingDF.iterrows()][1:-1])
+        endIndex = np.array([row['cellEnd'].name for idx, row in self.CrossingDF.iterrows()][1:-1])
+        boolReverseEdge = (startIndex[:-1] == startIndex[1:])
         if boolReverseEdge.any():
-            indxReverseEdge = np.where(boolReverseEdge)[0]+1
+            indxReverseEdge = np.where(boolReverseEdge)[0] + 1
             for id in indxReverseEdge:
                 self.CrossingDF = self.CrossingDF.drop(self.CrossingDF.iloc[id].name).sort_index().reset_index(drop=True)
 
-
-
-        self.CrossingDF.index = np.arange(0,int(len(self.CrossingDF)*1e3),int(1e3))
-
+        self.CrossingDF.index = np.arange(0, int(len(self.CrossingDF) * 1e3), int(1e3))
 
     def _updateCrossingPoint(self):
         '''
             FILL
         '''
 
-        self.org_triplet = copy.deepcopy(self.triplet) 
+        self.org_triplet = copy.deepcopy(self.triplet)
         self.speed_s = self._unit_speed(self.triplet.iloc[1]['cellStart']['Speed'])
         self.speed_e = self._unit_speed(self.triplet.iloc[1]['cellEnd']['Speed'])
 
         # ------ Case Deginitions & Dealing
         if self.debugging:
             print('===========================================================')
-        if abs(self.triplet.iloc[1].case)==2:
+        if abs(self.triplet.iloc[1].case) == 2:
             self._long_case()
-        elif abs(self.triplet.iloc[1].case)==4:
+        elif abs(self.triplet.iloc[1].case) == 4:
             self._lat_case()
-        elif (abs(self.triplet.iloc[1].case)==1) or (abs(self.triplet.iloc[1].case)==3):
+        elif (abs(self.triplet.iloc[1].case) == 1) or (abs(self.triplet.iloc[1].case) == 3):
             self._corner_case()
 
         if len(self.triplet) < 3:
             return
 
-
-
-
-    def _traveltime_in_cell(self,xdist,ydist,U,V,S):
+    def _traveltime_in_cell(self, xdist, ydist, U, V, S):
         '''
             FILL
         '''
-        dist  = np.sqrt(xdist**2 + ydist**2)
-        cval  = np.sqrt(U**2 + V**2)
+        dist = np.sqrt(xdist**2 + ydist**2)
+        cval = np.sqrt(U**2 + V**2)
 
-        dotprod  = xdist*U + ydist*V
+        dotprod = xdist * U + ydist * V
         diffsqrs = S**2 - cval**2
 
         # if (dotprod**2 + diffsqrs*(dist**2) < 0)
@@ -1088,31 +1057,31 @@ class NewtonianCurve:
                 return np.inf
                 #raise Exception(' ')
             else:
-                if ((dist**2)/(2*dotprod))  <0:
+                if ((dist**2) / (2 * dotprod)) < 0:
                     return np.inf
                     #raise Exception(' ')
                 else:
                     traveltime = dist * dist / (2 * dotprod)
                     return traveltime
 
-        traveltime = (np.sqrt(dotprod**2 + (dist**2)*diffsqrs) - dotprod)/diffsqrs
+        traveltime = (np.sqrt(dotprod**2 + (dist**2) * diffsqrs) - dotprod) / diffsqrs
         if traveltime < 0:
             traveltime = np.inf
         return traveltime, dist
 
-    def _waypoint_correction(self,source_graph,Wp,Cp):
+    def _waypoint_correction(self, source_graph, Wp, Cp):
         '''
             FILL
         '''
-        m_long  = 111.321*1000
-        m_lat   = 111.386*1000
+        m_long = 111.321 * 1000
+        m_lat = 111.386 * 1000
 
-        x = (Cp[0]-Wp[0])*m_long*np.cos(Wp[1]*(np.pi/180))
-        y = (Cp[1]-Wp[1])*m_lat
-        Su  = source_graph['Vector_x']*self.zc
-        Sv  = source_graph['Vector_y']*self.zc
+        x = (Cp[0] - Wp[0]) * m_long * np.cos(Wp[1] * (np.pi / 180))
+        y = (Cp[1] - Wp[1]) * m_lat
+        Su = source_graph['Vector_x'] * self.zc
+        Sv = source_graph['Vector_y'] * self.zc
         Ssp = self._unit_speed(source_graph['Speed'])
-        traveltime, distance = self._traveltime_in_cell(x,y,Su,Sv,Ssp)
+        traveltime, distance = self._traveltime_in_cell(x, y, Su, Sv, Ssp)
         return traveltime, distance
 
     def objective_function(self):
@@ -1120,20 +1089,19 @@ class NewtonianCurve:
             FILL
         '''
         TravelTime = np.zeros(len(self.CrossingDF))
-        Distance   = np.zeros(len(self.CrossingDF))
-        index      = np.zeros(len(self.CrossingDF))
-        for ii in range(len(self.CrossingDF)-1):
+        Distance = np.zeros(len(self.CrossingDF))
+        index = np.zeros(len(self.CrossingDF))
+        for ii in range(len(self.CrossingDF) - 1):
             soruce_graph = self.CrossingDF.iloc[ii]['cellEnd']
-            Wp = self.CrossingDF.iloc[ii][['cx','cy']].to_numpy()
-            Cp = self.CrossingDF.iloc[ii+1][['cx','cy']].to_numpy()
-            traveltime, distance = self._waypoint_correction(soruce_graph,Wp,Cp)
-            TravelTime[ii+1] = self._unit_time(traveltime)
-            Distance[ii+1]   = distance
+            Wp = self.CrossingDF.iloc[ii][['cx', 'cy']].to_numpy()
+            Cp = self.CrossingDF.iloc[ii + 1][['cx', 'cy']].to_numpy()
+            traveltime, distance = self._waypoint_correction(soruce_graph, Wp, Cp)
+            TravelTime[ii + 1] = self._unit_time(traveltime)
+            Distance[ii + 1] = distance
 
-            if ii ==0:
+            if ii == 0:
                 index[ii] = soruce_graph.name
-                index[ii+1] = soruce_graph.name
+                index[ii + 1] = soruce_graph.name
             else:
-                index[ii+1] = soruce_graph.name
-        return TravelTime,Distance,index
-
+                index[ii + 1] = soruce_graph.name
+        return TravelTime, Distance, index

--- a/polar_route/data_loaders.py
+++ b/polar_route/data_loaders.py
@@ -73,7 +73,7 @@ def load_amsr_folder(params, long_min, long_max, lat_min, lat_max, time_start, t
     # iterate through all files in folder passed as a parameter
     for file in sorted(glob.glob(params['folder'] + '/*.nc')):
         # string year/month/day out of file name.
-        # files in the folder must be named in the form 
+        # files in the folder must be named in the form
         # asi-AMSR2-s6250-<year><month><day>-v.5.4.nc
         year = int(file.split('-')[-2][0:4])
         month = int(file.split('-')[-2][4:6])
@@ -412,11 +412,11 @@ def load_bsose(params, long_min, long_max, lat_min, lat_max, time_start, time_en
 
     if 'units' in params.keys():
         if params['units'] == "percentage":
-            bsose_df['SIC'] = bsose_df['SIC']*100
+            bsose_df['SIC'] = bsose_df['SIC'] * 100
         if params['units'] == 'fraction':
-            """""" #BSOSE source data is fractional, no transformation required
+            """"""  # BSOSE source data is fractional, no transformation required
     else:
-        bsose_df['SIC'] = bsose_df['SIC']*100
+        bsose_df['SIC'] = bsose_df['SIC'] * 100
 
     bsose_df = bsose_df[bsose_df['long'].between(long_min, long_max)]
     bsose_df = bsose_df[bsose_df['lat'].between(lat_min, lat_max)]
@@ -548,16 +548,15 @@ def load_gebco(params, long_min, long_max, lat_min, lat_max, time_start, time_en
             gebco_df (Dataframe): A dataframe containing GEBCO elevation
                 data. The dataframe is of the format -
 
-                lat | long | time | elevation 
+                lat | long | time | elevation
     """
     logging.debug("opening file {}".format(params['file']))
     gebco = xr.open_dataset(params['file'])
 
-    
     if 'downsample_factors' in params.keys():
         logging.debug("downsampling dataset by a factor of [{},{}]".format(params['downsample_factors'][0],
-            params['downsample_factors'][1] ))
-        elev = gebco['elevation'][::params['downsample_factors'][0],::params['downsample_factors'][1]]
+                                                                           params['downsample_factors'][1]))
+        elev = gebco['elevation'][::params['downsample_factors'][0], ::params['downsample_factors'][1]]
         gebco = xr.Dataset()
         gebco['elevation'] = elev
 
@@ -621,7 +620,7 @@ def load_sose_currents(params, long_min, long_max, lat_min, lat_max, time_start,
             sose_df['uC'] = sose_df['uC'] * 3.6
             sose_df['vC'] = sose_df['vC'] * 3.6
         if params['units'] == 'm/s':
-            """""" # SOSE source data is in m/s, no transformation required
+            """"""  # SOSE source data is in m/s, no transformation required
 
     logging.debug("returning {} datapoints".format(len(sose_df.index)))
     return sose_df
@@ -690,7 +689,7 @@ def load_modis(params, long_min, long_max, lat_min, lat_max, time_start, time_en
 
             params (dict): A dictionary containing optional parameters. This
                 function requires -
-  
+
                 params['file'] (string): file location of the MODIS dataset
 
         Returns:
@@ -709,7 +708,7 @@ def load_modis(params, long_min, long_max, lat_min, lat_max, time_start, time_en
     # set the SIC of that datapoint to NaN
     modis_df['iceArea'] = np.where(modis_df['cloud'] == 1, np.NaN, modis_df['iceArea'])
     modis_df = modis_df.rename(columns={'iceArea': 'SIC'})
-    modis_df['SIC'] = modis_df['SIC']*10.
+    modis_df['SIC'] = modis_df['SIC'] * 10.
 
     modis_df = modis_df[modis_df['long'].between(long_min, long_max)]
     modis_df = modis_df[modis_df['lat'].between(lat_min, lat_max)]
@@ -748,7 +747,7 @@ def load_era5_wind(params, long_min, long_max, lat_min, lat_max, time_start, tim
     logging.debug("opening file {}".format(params['file']))
     era5_wind = xr.open_dataset(params['file'])
 
-    # era5_wind data is available in monthly slices, not daily. 
+    # era5_wind data is available in monthly slices, not daily.
     # time_start is set to the start of the given month to ensure that data is loaded.
     time_start_split = time_start.split('-')
     time_start = time_start_split[0] + "-" + time_start_split[1] + "-01"
@@ -809,7 +808,7 @@ def load_oras5(params, long_min, long_max, lat_min, lat_max, time_start, time_en
     oras5_df = oras5.to_dataframe()
     oras5_df = oras5_df.reset_index()
 
-    oras5_df = oras5_df.rename(columns={'uo': 'uC','vo': 'vC','longitude':'long','latitude':'lat'})
+    oras5_df = oras5_df.rename(columns={'uo': 'uC', 'vo': 'vC', 'longitude': 'long', 'latitude': 'lat'})
     oras5_df = oras5_df[oras5_df['long'].between(long_min, long_max)]
     oras5_df = oras5_df[oras5_df['lat'].between(lat_min, lat_max)]
     logging.debug("returned {} datapoints".format(len(oras5_df.index)))

--- a/polar_route/mesh.py
+++ b/polar_route/mesh.py
@@ -208,8 +208,8 @@ class Mesh:
             logging.debug("J_grid using loader {}".format(loader_name))
 
             data_points = loader(self.config['Mesh_info']['j_grid']['Currents']['params'],
-                self._long_min, self._long_max, self._lat_min, self._lat_max,
-                self._start_time, self._end_time)
+                                 self._long_min, self._long_max, self._lat_min, self._lat_max,
+                                 self._start_time, self._end_time)
 
             self.add_current_points(data_points)
 
@@ -755,7 +755,7 @@ class Mesh:
                     n_neighbour_indx = self.neighbour_graph[cellbox_indx][-4]
                     for neighbour in n_neighbour_indx:
                         if (not self.cellboxes[neighbour].land_locked) and (
-                            self.cellboxes[neighbour].get_value('SIC') < max_ice_area):
+                                self.cellboxes[neighbour].get_value('SIC') < max_ice_area):
                             graph_dump += "," + self.cellboxes[neighbour].node_string() + ":-4"
                     # case 4 neighbours
                     s_neighbours_indx = self.neighbour_graph[cellbox_indx][4]
@@ -811,7 +811,7 @@ class Mesh:
             if np.isnan(point['uC'].mean()) or np.isnan(point['vC'].mean()):
                 cellbox.land_locked = True
 
-            #cellbox.set_land()
+            # cellbox.set_land()
 
     def cellbox_by_node_string(self, node_string):
         """

--- a/polar_route/plot.py
+++ b/polar_route/plot.py
@@ -1,8 +1,8 @@
 """
 Outlined in this section we will discuss the usage of the automated plotting functionallity
-of the pyRoutePlanner. In this series of class distributions we house our interactive web based plots as well 
+of the pyRoutePlanner. In this series of class distributions we house our interactive web based plots as well
 static plots ready for publication usage.
-representation of input data. In each CellBox we determine the mean and variance of 
+representation of input data. In each CellBox we determine the mean and variance of
 the information goverining our nemerical world, this includes and is not limited to:
 Ocean Currents, Sea Ice Concentration, Bathemetric depth, whether on land.
 
@@ -25,9 +25,16 @@ Todo:
 """
 
 
-
-
-
+import cartopy.io.img_tiles as cimgt
+import cartopy.feature as cfeature
+import matplotlib.pyplot as plt
+import cartopy.crs as ccrs
+from shapely.geometry.polygon import Polygon
+from mpl_toolkits.axes_grid1.inset_locator import inset_axes
+from matplotlib.collections import LineCollection
+from jinja2 import Template
+from branca.element import MacroElement
+import branca
 import copy
 import json
 import pandas as pd
@@ -45,14 +52,8 @@ from shapely.geometry import Polygon
 sys.path.insert(0, 'folium')
 sys.path.insert(0, 'branca')
 
-import branca
-import folium
 
 # Adapted from: https://nbviewer.org/gist/BibMartin/f153aa957ddc5fadc64929abdee9ff2e
-from branca.element import MacroElement
-from jinja2 import Template
-from matplotlib.collections import LineCollection
-from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 
 
 class BindColormap(MacroElement):
@@ -63,6 +64,7 @@ class BindColormap(MacroElement):
     colormap : branca.colormap.ColorMap
         The colormap to bind.
     """
+
     def __init__(self, layer, colormap):
         super(BindColormap, self).__init__()
         self.layer = layer
@@ -80,7 +82,6 @@ class BindColormap(MacroElement):
                 }});
         {% endmacro %}
         """)  # noqa
-
 
 
 def deep_search(needles, haystack):
@@ -107,45 +108,31 @@ def deep_search(needles, haystack):
     return found
 
 
-
-from shapely.geometry.polygon import Polygon
-import cartopy.crs as ccrs
-import matplotlib.pyplot as plt
-from shapely import wkt
-import cartopy.feature as cfeature
-import pandas as pd
-import cartopy.io.img_tiles as cimgt
-import json
-
-
 class StaticMap:
     def __init__(self, json):
-    
+
         self.json = json
-        self.config  = json['config']
+        self.config = json['config']
         self.basemap = self.config["Static_Map"]['Basemap_Info']
-        self.layers  = self.config['Static_Map']['Layers']
-        cellboxes    = json['cellboxes']
-        
+        self.layers = self.config['Static_Map']['Layers']
+        cellboxes = json['cellboxes']
 
-
-        #Initialising the basemap
+        # Initialising the basemap
         if 'CRS' in self.basemap:
             if self.basemap['CRS'] == 'Mercartor':
                 self.ccrs = ccrs.Mercator()
             if self.basemap['CRS'] == 'Orthographic':
-                self.ccrs = ccrs.Orthographic(central_longitude=self.basemap['central_longitude'],central_latitude=self.basemap['central_latitude'])
+                self.ccrs = ccrs.Orthographic(central_longitude=self.basemap['central_longitude'], central_latitude=self.basemap['central_latitude'])
         else:
-           self.ccrs = ccrs.Mercator()
+            self.ccrs = ccrs.Mercator()
         self._basemap()
-
 
         # Overlaying the layers
         for idx, layer in enumerate(self.layers):
-            self.zorder = idx+1
+            self.zorder = idx + 1
             if not layer['Show']:
                 continue
-            #try:
+            # try:
             if layer['Type'] == 'Maps':
                 self._maps(layer, cellboxes)
             if layer['Type'] == 'Paths':
@@ -156,25 +143,24 @@ class StaticMap:
         if 'Output_Filename' in self.config['Static_Map']:
             plt.savefig(self.config['Static_Map']['Output_Filename'])
 
-
     def _basemap(self):
-        self.fig = plt.figure(figsize=(15,15))
+        self.fig = plt.figure(figsize=(15, 15))
         matplotlib.rcParams.update({'font.size': 16})
 
         self.ax = plt.axes(projection=self.ccrs)
-        self.ax.set_extent([self.config['Mesh_info']['Region']['longMin']+1e-6,self.config['Mesh_info']['Region']['longMax']-1e-6,self.config['Mesh_info']['Region']['latMin'],self.config['Mesh_info']['Region']['latMax']], crs=ccrs.PlateCarree())
+        self.ax.set_extent([self.config['Mesh_info']['Region']['longMin'] + 1e-6, self.config['Mesh_info']['Region']['longMax'] - 1e-6, self.config['Mesh_info']['Region']['latMin'], self.config['Mesh_info']['Region']['latMax']], crs=ccrs.PlateCarree())
         self.ax.add_image(cimgt.GoogleTiles(), 3)
         self.ax.coastlines(resolution='50m')
-        self.ax.gridlines(draw_labels=True, dms=True, x_inline=False, y_inline=False,linewidth=0.5,linestyle='--')
+        self.ax.gridlines(draw_labels=True, dms=True, x_inline=False, y_inline=False, linewidth=0.5, linestyle='--')
         self.ax.add_feature(cfeature.BORDERS)
-        plt.title(r'Route Planner | {}'.format(self.basemap['Title']),fontsize=14,loc='left',color='blue')
+        plt.title(r'Route Planner | {}'.format(self.basemap['Title']), fontsize=14, loc='left', color='blue')
 
-    def _points(self,info):
+    def _points(self, info):
 
         if 'filename' in info:
             dataframe_points = pd.read_csv(info['filename'])
         elif 'object' in info:
-            dataframe_points = pd.DataFrame(deep_search([info['object']],self.json )[info['object']])
+            dataframe_points = pd.DataFrame(deep_search([info['object']], self.json)[info['object']])
         else:
             print('Please define either a filename or object in the json')
 
@@ -187,12 +173,11 @@ class StaticMap:
                 colour = [cmap.rgba_floats_tuple(ii) for ii in np.array(dataframe_points[info['Name']])]
             else:
                 colour = info['Color']
-            self.ax.scatter(dataframe_points['Long'],dataframe_points['Lat'],info["Size"],c=colour,marker='o',transform=ccrs.PlateCarree(),zorder=self.zorder)
+            self.ax.scatter(dataframe_points['Long'], dataframe_points['Lat'], info["Size"], c=colour, marker='o', transform=ccrs.PlateCarree(), zorder=self.zorder)
         else:
-            self.ax.scatter(dataframe_points['Long'],dataframe_points['Lat'],info["Size"],marker='o',transform=ccrs.PlateCarree(),color=info['Color'],zorder=self.zorder)
+            self.ax.scatter(dataframe_points['Long'], dataframe_points['Lat'], info["Size"], marker='o', transform=ccrs.PlateCarree(), color=info['Color'], zorder=self.zorder)
 
-
-    def _paths(self,info):
+    def _paths(self, info):
         '''
             Plotting a paths type object
         '''
@@ -203,7 +188,7 @@ class StaticMap:
             with open(info['filename'], 'r') as f:
                 geojson = json.load(f)
         elif 'object' in info:
-            geojson = deep_search([info['object']],self.json)[info['object']]
+            geojson = deep_search([info['object']], self.json)[info['object']]
         else:
             print('Please define either a filename or object in the json')
         paths = geojson['features']
@@ -220,103 +205,97 @@ class StaticMap:
 
         # Determining max travel-times of all paths
         for path in paths:
-            points   = np.array(path['geometry']['coordinates'])
+            points = np.array(path['geometry']['coordinates'])
             if 'Data_Name' in info:
                 data_val = np.array(path['properties'][info['Data_Name']])
             else:
                 data_val = np.array(len(points))
 
-
             if info['Colorline']:
                 # Add ColorLines
-                x = self.ccrs.transform_points(x=points[:,0], y=points[:,1],
-                                                src_crs=ccrs.PlateCarree())
-                xcs = np.array([x[:,0],x[:,1]]).T.reshape(-1,1,2) 
-                segments = np.concatenate([xcs[:-1], xcs[1:]], axis=1)   
-                lc = LineCollection(segments, cmap=info['Cmap'], linewidth=info['Line_Width'],norm=plt.Normalize(vmin=min_val, vmax=max_val),zorder=self.zorder) 
-                lc.set_array(path['properties']['traveltime'])                                           
-                self.ax.add_collection(lc) 
-                
-            
+                x = self.ccrs.transform_points(x=points[:, 0], y=points[:, 1],
+                                               src_crs=ccrs.PlateCarree())
+                xcs = np.array([x[:, 0], x[:, 1]]).T.reshape(-1, 1, 2)
+                segments = np.concatenate([xcs[:-1], xcs[1:]], axis=1)
+                lc = LineCollection(segments, cmap=info['Cmap'], linewidth=info['Line_Width'], norm=plt.Normalize(vmin=min_val, vmax=max_val), zorder=self.zorder)
+                lc.set_array(path['properties']['traveltime'])
+                self.ax.add_collection(lc)
+
             else:
-                self.ax.plot(points[:,0],points[:,1],transform=ccrs.PlateCarree(),linewidth=info['Line_Width'],color=info['Color'],alpha=1.,zorder=self.zorder)
+                self.ax.plot(points[:, 0], points[:, 1], transform=ccrs.PlateCarree(), linewidth=info['Line_Width'], color=info['Color'], alpha=1., zorder=self.zorder)
 
             if info['Path_Points']:
-                self.ax.scatter(points[:,0],points[:,1],color=info['Color'],)
-        
+                self.ax.scatter(points[:, 0], points[:, 1], color=info['Color'],)
+
         if info['Colorline']:
-            cbaxes = inset_axes(self.ax, '25%', '3%', loc =1)
-            cbaxes.set_facecolor([1,1,1,0.7])
-            cb=self.fig.colorbar(lc,cax=cbaxes,orientation='horizontal',label='Traveltime') #make colorbar
+            cbaxes = inset_axes(self.ax, '25%', '3%', loc=1)
+            cbaxes.set_facecolor([1, 1, 1, 0.7])
+            cb = self.fig.colorbar(lc, cax=cbaxes, orientation='horizontal', label='Traveltime')  # make colorbar
 
+    def _maps(self, info, cellboxes):
+        '''
+            Plotting a map type object
+        '''
+        dataframe_pandas = pd.DataFrame(cellboxes)
+        #dataframe_pandas = pd.read_csv(info['filename'])
+        dataframe_pandas['geometry'] = dataframe_pandas['geometry'].apply(wkt.loads)
+        dataframe_geo = gpd.GeoDataFrame(dataframe_pandas, crs='EPSG:4326', geometry='geometry')
 
+        if dataframe_geo[info['Data_Name']].dtype == 'bool':
+            for _, poly in dataframe_geo.iterrows():
+                if poly[info['Data_Name']]:
+                    self.ax.add_geometries([poly['geometry']], crs=ccrs.PlateCarree(), edgecolor=info['Line_Color'], facecolor=info['Fill_Color'], alpha=info['Fill_Opacity'], lw=info['Line_Width'], zorder=self.zorder)
 
-    def _maps(self,info, cellboxes):
-            '''
-                Plotting a map type object
-            '''
-            dataframe_pandas = pd.DataFrame(cellboxes)
-            #dataframe_pandas = pd.read_csv(info['filename'])
-            dataframe_pandas['geometry'] = dataframe_pandas['geometry'].apply(wkt.loads)
-            dataframe_geo = gpd.GeoDataFrame(dataframe_pandas,crs='EPSG:4326', geometry='geometry')
+        if dataframe_geo[info['Data_Name']].dtype == float:
+            if ('Fill_trim_min' not in info):
+                info['Fill_trim_min'] = dataframe_geo[info['Data_Name']].min()
+            if ('Fill_trim_max' not in info):
+                info['Fill_trim_max'] = dataframe_geo[info['Data_Name']].max()
 
-            if dataframe_geo[info['Data_Name']].dtype == 'bool':
-                for _,poly in dataframe_geo.iterrows():
-                    if poly[info['Data_Name']]:
-                        self.ax.add_geometries([poly['geometry']], crs=ccrs.PlateCarree(), edgecolor=info['Line_Color'], facecolor=info['Fill_Color'],alpha=info['Fill_Opacity'],lw=info['Line_Width'],zorder=self.zorder)
+            dataframe_geo = dataframe_geo[(dataframe_geo[info['Data_Name']] >= info['Fill_trim_min']) &
+                                          (dataframe_geo[info['Data_Name']] <= info['Fill_trim_max'])]
 
-
-            if dataframe_geo[info['Data_Name']].dtype == float:
-                if ('Fill_trim_min' not in info):
-                    info['Fill_trim_min'] = dataframe_geo[info['Data_Name']].min()
-                if ('Fill_trim_max' not in info):
-                    info['Fill_trim_max'] = dataframe_geo[info['Data_Name']].max()
-
-                dataframe_geo = dataframe_geo[(dataframe_geo[info['Data_Name']] >= info['Fill_trim_min']) &
-                                            (dataframe_geo[info['Data_Name']] <= info['Fill_trim_max'])]
-
-                if info['Fill_cmap_use']:
-                    if 'Fill_cmap_opacity' not in info:
-                        info['Fill_cmap_opacity'] = False
-                    if info['Fill_cmap_opacity']:
-                        for _,poly in dataframe_geo.iterrows():
-                            self.ax.add_geometries([poly['geometry']], crs=ccrs.PlateCarree(), edgecolor=info['Line_Color'], facecolor=info['Fill_Color'],alpha=poly[info['Data_Name']]/info['Fill_cmap_opacity_scalar'],lw=info['Line_Width'],zorder=self.zorder)
-                    else:
-                        if 'Fill_cmap_min' in info:
-                            cmin = info['Fill_cmap_min']
-                        else:
-                            cmin = dataframe_geo[info['Data_Name']].min()
-                        if 'Fill_cmap_max' in info:
-                            cmax = info['Fill_cmap_max']
-                        else:
-                            cmax = dataframe_geo[info['Data_Name']].max()
-                            # Define a colormap version
-                            cmap = linear._colormaps[info['Cmap']].scale(info['Fill_trim_min'], info['Fill_trim_max'])
-                            for indx,row in dataframe_geo.iterrows():
-                                data = row[info['Data_Name']]
-                                if not np.isnan(data):
-                                    colour = cmap.rgba_floats_tuple(data)
-                                    self.ax.add_geometries([row['geometry']], facecolor = colour, crs = ccrs.PlateCarree(), alpha = info['Fill_Opacity'],zorder=self.zorder)
+            if info['Fill_cmap_use']:
+                if 'Fill_cmap_opacity' not in info:
+                    info['Fill_cmap_opacity'] = False
+                if info['Fill_cmap_opacity']:
+                    for _, poly in dataframe_geo.iterrows():
+                        self.ax.add_geometries([poly['geometry']], crs=ccrs.PlateCarree(), edgecolor=info['Line_Color'], facecolor=info['Fill_Color'], alpha=poly[info['Data_Name']] / info['Fill_cmap_opacity_scalar'], lw=info['Line_Width'], zorder=self.zorder)
                 else:
-                    if (info['Fill_Opacity'] == 0.0):
-                        for _,poly in dataframe_geo.iterrows():
-                            x,y = poly['geometry'].exterior.coords.xy
-                            self.ax.plot(np.array(x),np.array(y),color=info['Line_Color'],linewidth=info['Line_Width'],transform=ccrs.PlateCarree(),zorder=self.zorder)
+                    if 'Fill_cmap_min' in info:
+                        cmin = info['Fill_cmap_min']
+                    else:
+                        cmin = dataframe_geo[info['Data_Name']].min()
+                    if 'Fill_cmap_max' in info:
+                        cmax = info['Fill_cmap_max']
+                    else:
+                        cmax = dataframe_geo[info['Data_Name']].max()
+                        # Define a colormap version
+                        cmap = linear._colormaps[info['Cmap']].scale(info['Fill_trim_min'], info['Fill_trim_max'])
+                        for indx, row in dataframe_geo.iterrows():
+                            data = row[info['Data_Name']]
+                            if not np.isnan(data):
+                                colour = cmap.rgba_floats_tuple(data)
+                                self.ax.add_geometries([row['geometry']], facecolor=colour, crs=ccrs.PlateCarree(), alpha=info['Fill_Opacity'], zorder=self.zorder)
+            else:
+                if (info['Fill_Opacity'] == 0.0):
+                    for _, poly in dataframe_geo.iterrows():
+                        x, y = poly['geometry'].exterior.coords.xy
+                        self.ax.plot(np.array(x), np.array(y), color=info['Line_Color'], linewidth=info['Line_Width'], transform=ccrs.PlateCarree(), zorder=self.zorder)
+
     def show(self):
         plt.show()
 
 
 class InteractiveMap:
-    def __init__(self,config):
+    def __init__(self, config):
         self.config = config
 
         self.basemap = config["Interactive_Map"]['Basemap_Info']
-        self.layers  = config['Interactive_Map']['Layers']
-
+        self.layers = config['Interactive_Map']['Layers']
 
         # Initialising the basemap
         self._basemap()
-
 
         # Defining the layers to plot
         for layer in self.layers:
@@ -324,7 +303,7 @@ class InteractiveMap:
                 if layer['Type'] == 'Paths':
                     self._paths(layer)
                 if layer['Type'] == 'Maps':
-                    self._maps(layer) 
+                    self._maps(layer)
                 if layer['Type'] == 'Points':
                     self._points(layer)
                 if layer['Type'] == 'Geotiff':
@@ -333,7 +312,7 @@ class InteractiveMap:
                     self._meshInfo(layer)
             except:
                 print('Issue Plotting Layer')
-                    
+
         # Adding in the layer control
         self._layer_control()
 
@@ -341,45 +320,42 @@ class InteractiveMap:
         if 'Output_Filename' in self.config['Interactive_Map']:
             self.map.save(self.config['Interactive_Map']['Output_Filename'])
 
-
     def _basemap(self):
         '''
             Defining the basemap structure
         '''
         title_html = '''
             <h1 style="color:#003b5c;font-size:16px">
-            &ensp;<img src='https://i.ibb.co/JH2zknX/Small-Logo.png' alt="BAS-colour-eps" border="0" style="width:40px;height:40px;"> 
-            <img src="https://i.ibb.co/XtZdzDt/BAS-colour-eps.png" alt="BAS-colour-eps" border="0" style="width:179px;height:40px;"> 
+            &ensp;<img src='https://i.ibb.co/JH2zknX/Small-Logo.png' alt="BAS-colour-eps" border="0" style="width:40px;height:40px;">
+            <img src="https://i.ibb.co/XtZdzDt/BAS-colour-eps.png" alt="BAS-colour-eps" border="0" style="width:179px;height:40px;">
             &ensp;|&ensp; RoutePlanner &ensp;|&ensp; {}
             </h1>
             </body>
-            '''.format(self.basemap['Title'])   
-        self.map = folium.Map(location=self.basemap['Map_Centre'],zoom_start=self.basemap['Map_Zoom'],tiles=None)
-        
-        # 
+            '''.format(self.basemap['Title'])
+        self.map = folium.Map(location=self.basemap['Map_Centre'], zoom_start=self.basemap['Map_Zoom'], tiles=None)
+
+        #
         bsmap = folium.FeatureGroup(name='BaseMap')
-        folium.TileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}.png',attr="toner-bcg", name='Basemap').add_to(bsmap)
+        folium.TileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}.png', attr="toner-bcg", name='Basemap').add_to(bsmap)
         bsmap.add_to(self.map)
-        bsmap = folium.FeatureGroup(name='Dark BaseMap',show=False)
-        folium.TileLayer(tiles="https://{s}.basemaps.cartocdn.com/rastertiles/dark_all/{z}/{x}/{y}.png",attr='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',name='darkmatter').add_to(bsmap)
+        bsmap = folium.FeatureGroup(name='Dark BaseMap', show=False)
+        folium.TileLayer(tiles="https://{s}.basemaps.cartocdn.com/rastertiles/dark_all/{z}/{x}/{y}.png", attr='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>', name='darkmatter').add_to(bsmap)
         bsmap.add_to(self.map)
-
-
 
         self.map.get_root().html.add_child(folium.Element(title_html))
-        
-    def _paths(self,info):
+
+    def _paths(self, info):
         '''
             Plotting a paths type object
         '''
 
-        #map,PathPoints=True,PathName='Transit Time', colorLine=True
-        
+        # map,PathPoints=True,PathName='Transit Time', colorLine=True
+
         # Defining the feature groups to add
-        pths        = folium.FeatureGroup(name='{}'.format(info['Name']),show=info['Show'])
+        pths = folium.FeatureGroup(name='{}'.format(info['Name']), show=info['Show'])
         if info['Path_Points']:
-            pths_points = folium.FeatureGroup(name='{} - Path Points'.format(info['Name']),show=info['Show'])
-            
+            pths_points = folium.FeatureGroup(name='{} - Path Points'.format(info['Name']), show=info['Show'])
+
         # Loading the path information
         with open(info['filename'], 'r') as f:
             geojson = json.load(f)
@@ -394,106 +370,98 @@ class InteractiveMap:
 
         # Determining max travel-times of all paths
         for path in paths:
-            points   = np.array(path['geometry']['coordinates'])
+            points = np.array(path['geometry']['coordinates'])
             if 'Data_Name' in info:
                 data_val = np.array(path['properties'][info['Data_Name']])
             else:
                 data_val = np.array(len(points))
 
-            points[:,0] = points[:,0]
-            points = points[:,::-1]
+            points[:, 0] = points[:, 0]
+            points = points[:, ::-1]
 
             if info['Colorline']:
                 #folium.PolyLine(points,color="black", weight=info['Line_Width'], opacity=1).add_to(pths)
-                colormap = linear._colormaps[info['Cmap']].scale(0,max_val)
-                colormap.caption = '{} ({},Max Value={:.3f})'.format(info['Data_Name'],info['Data_Units'],max_val)
-                folium.ColorLine(points,data_val,colormap=colormap,nb_steps=50, weight=info['Line_Width'], opacity=1).add_to(pths)
-
-
+                colormap = linear._colormaps[info['Cmap']].scale(0, max_val)
+                colormap.caption = '{} ({},Max Value={:.3f})'.format(info['Data_Name'], info['Data_Units'], max_val)
+                folium.ColorLine(points, data_val, colormap=colormap, nb_steps=50, weight=info['Line_Width'], opacity=1).add_to(pths)
 
             else:
-                folium.PolyLine(points,color=info['Color'], weight=info['Line_Width'], opacity=1).add_to(pths)
-
+                folium.PolyLine(points, color=info['Color'], weight=info['Line_Width'], opacity=1).add_to(pths)
 
             if info['Path_Points']:
                 for idx in range(len(points)):
-                    loc = [points[idx,0],points[idx,1]]
+                    loc = [points[idx, 0], points[idx, 1]]
                     folium.Marker(
                         location=loc,
                         icon=folium.plugins.BeautifyIcon(icon='circle',
-                                                    border_color='transparent',
-                                                    background_color='transparent',
-                                                    border_width=1,
-                                                    text_color=info['Color'],
-                                                    inner_icon_style='margin:0px;font-size:0.8em')
+                                                         border_color='transparent',
+                                                         background_color='transparent',
+                                                         border_width=1,
+                                                         text_color=info['Color'],
+                                                         inner_icon_style='margin:0px;font-size:0.8em')
                     ).add_to(pths_points)
-        
+
         if info['Path_Points']:
             pths_points.add_to(self.map)
         if info['Colorline']:
             self.map.add_child(pths)
             self.map.add_child(colormap)
-            self.map.add_child(BindColormap(pths,colormap))
+            self.map.add_child(BindColormap(pths, colormap))
         else:
             pths.add_to(self.map)
 
+    def _points(self, info):
 
-    def _points(self,info):
-
-        wpts = folium.FeatureGroup(name='{}'.format(info['Name']),show=info['Show'])
-        wpts_name = folium.FeatureGroup(name='{} - Names'.format(info['Name']),show=info['Show'])
+        wpts = folium.FeatureGroup(name='{}'.format(info['Name']), show=info['Show'])
+        wpts_name = folium.FeatureGroup(name='{} - Names'.format(info['Name']), show=info['Show'])
 
         dataframe_points = pd.read_csv(info['filename'])
 
-
-        for id,wpt in dataframe_points.iterrows():
+        for id, wpt in dataframe_points.iterrows():
             loc = [wpt['Lat'], wpt['Long']]
             folium.Marker(
                 location=loc,
                 icon=plugins.BeautifyIcon(icon='circle',
-                                                border_color='transparent',
-                                                background_color='transparent',
-                                                border_width=info['Border_Width'],
-                                                text_color=info['Color'],
-                                                inner_icon_style='margin:0px;font-size:0.8em'),
-                popup="<b>{} [{:4f},{:4f}]</b>".format(wpt['Name'],loc[0],loc[1]),
-            ).add_to(wpts)    
+                                          border_color='transparent',
+                                          background_color='transparent',
+                                          border_width=info['Border_Width'],
+                                          text_color=info['Color'],
+                                          inner_icon_style='margin:0px;font-size:0.8em'),
+                popup="<b>{} [{:4f},{:4f}]</b>".format(wpt['Name'], loc[0], loc[1]),
+            ).add_to(wpts)
 
             folium.Marker(
-                        location=loc,
-                            icon=folium.features.DivIcon(
-                                icon_size=(250,36),
-                                icon_anchor=(0,0),
-                                html='<div style="font-size: {}pt">{}</div>'.format(info['Font_Size'],wpt['Name']),
-                                ),
+                location=loc,
+                icon=folium.features.DivIcon(
+                    icon_size=(250, 36),
+                    icon_anchor=(0, 0),
+                    html='<div style="font-size: {}pt">{}</div>'.format(info['Font_Size'], wpt['Name']),
+                ),
             ).add_to(wpts_name)
-
 
         wpts.add_to(self.map)
         wpts_name.add_to(self.map)
 
-
-    def _maps(self,info):
+    def _maps(self, info):
         '''
             Plotting a map type object
         '''
 
         dataframe_pandas = pd.read_csv(info['filename'])
         dataframe_pandas['geometry'] = dataframe_pandas['geometry'].apply(wkt.loads)
-        dataframe_geo = gpd.GeoDataFrame(dataframe_pandas,crs='EPSG:4326', geometry='geometry')
+        dataframe_geo = gpd.GeoDataFrame(dataframe_pandas, crs='EPSG:4326', geometry='geometry')
 
-
-        feature_info = folium.FeatureGroup(name='{}'.format(info['Name']),show=info['Show'])
+        feature_info = folium.FeatureGroup(name='{}'.format(info['Name']), show=info['Show'])
 
         if dataframe_geo[info['Data_Name']].dtype == 'bool':
             folium.GeoJson(
-                dataframe_geo[dataframe_geo[info['Data_Name']]==True],
+                dataframe_geo[dataframe_geo[info['Data_Name']]],
                 style_function=lambda x: {
                     'fillColor': info['Fill_Color'],
                     'color': info['Line_Color'],
                     'weight': info['Line_Width'],
                     'fillOpacity': info['Fill_Opacity']
-                    }
+                }
             ).add_to(feature_info)
 
             feature_info.add_to(self.map)
@@ -503,10 +471,10 @@ class InteractiveMap:
             if ('Fill_trim_min' not in info):
                 info['Fill_trim_min'] = dataframe_geo[info['Data_Name']].min()
             if ('Fill_trim_max' not in info):
-                info['Fill_trim_max'] = dataframe_geo[info['Data_Name']].max()            
+                info['Fill_trim_max'] = dataframe_geo[info['Data_Name']].max()
 
             dataframe_geo = dataframe_geo[(dataframe_geo[info['Data_Name']] >= info['Fill_trim_min']) &
-                                        (dataframe_geo[info['Data_Name']] <= info['Fill_trim_max'])]
+                                          (dataframe_geo[info['Data_Name']] <= info['Fill_trim_max'])]
 
             if info['Fill_cmap_use']:
 
@@ -517,11 +485,11 @@ class InteractiveMap:
                     folium.GeoJson(
                         dataframe_geo,
                         style_function=lambda x: {
-                                'fillColor': info['Fill_Color'],
-                                'color': info['Line_Color'],
-                                'weight': info['Line_Width'],
-                                'fillOpacity': x['properties'][info['Data_Name']]/info['Fill_cmap_opacity_scalar']
-                            }
+                            'fillColor': info['Fill_Color'],
+                            'color': info['Line_Color'],
+                            'weight': info['Line_Width'],
+                            'fillOpacity': x['properties'][info['Data_Name']] / info['Fill_cmap_opacity_scalar']
+                        }
                     ).add_to(feature_info)
                     self.map.add_child(feature_info)
 
@@ -535,20 +503,20 @@ class InteractiveMap:
                     else:
                         cmax = dataframe_geo[info['Data_Name']].max()
 
-                    colormap = linear._colormaps[info['Cmap']].scale(cmin,cmax)
-                    colormap.caption = '{} ({})'.format(info['Data_Name'],info['Data_Units'])
+                    colormap = linear._colormaps[info['Cmap']].scale(cmin, cmax)
+                    colormap.caption = '{} ({})'.format(info['Data_Name'], info['Data_Units'])
                     folium.GeoJson(
                         dataframe_geo,
                         style_function=lambda x: {
-                                'fillColor': colormap(x['properties'][info['Data_Name']]),
-                                'color': info['Line_Color'],
-                                'weight': info['Line_Width'],
-                                'fillOpacity': info['Fill_Opacity']
-                            }
+                            'fillColor': colormap(x['properties'][info['Data_Name']]),
+                            'color': info['Line_Color'],
+                            'weight': info['Line_Width'],
+                            'fillOpacity': info['Fill_Opacity']
+                        }
                     ).add_to(feature_info)
                     self.map.add_child(feature_info)
                     self.map.add_child(colormap)
-                    self.map.add_child(BindColormap(feature_info,colormap))
+                    self.map.add_child(BindColormap(feature_info, colormap))
             else:
                 folium.GeoJson(
                     dataframe_geo,
@@ -557,7 +525,7 @@ class InteractiveMap:
                         'color': info['Line_Color'],
                         'weight': info['Line_Width'],
                         'fillOpacity': info['Fill_Opacity']
-                        }
+                    }
                 ).add_to(feature_info)
 
                 self.map.add_child(feature_info)
@@ -574,35 +542,35 @@ class InteractiveMap:
     #     "Data_Names":["cell_info"]
     #   },
 
-    def _meshInfo(self,info):
+    def _meshInfo(self, info):
         dataframe_pandas = pd.read_csv(info['filename'])
         dataframe_pandas['geometry'] = dataframe_pandas['geometry'].apply(wkt.loads)
-        dataframe_geo = gpd.GeoDataFrame(dataframe_pandas,crs='EPSG:4326', geometry='geometry')
-        dataframe_geo = dataframe_geo[['geometry']+list(info['Data_Names'])]
+        dataframe_geo = gpd.GeoDataFrame(dataframe_pandas, crs='EPSG:4326', geometry='geometry')
+        dataframe_geo = dataframe_geo[['geometry'] + list(info['Data_Names'])]
 
-        feature_info = folium.FeatureGroup(name='{}'.format(info['Name']),show=info['Show'])
+        feature_info = folium.FeatureGroup(name='{}'.format(info['Name']), show=info['Show'])
         folium.GeoJson(dataframe_geo,
-            style_function= lambda x: {
-                    'fillColor': info['Fill_Color'],
-                    'color': info['Line_Color'],
-                    'weight': info['Line_Width'],
-                    'fillOpacity': info['Fill_Opacity']
-                },
-            tooltip=folium.GeoJsonTooltip(
-                fields=list(dataframe_geo.columns.intersection(info['Data_Names'])),
-                aliases=info['Label_Names'],
-                localize=True
-            )
-        ).add_to(feature_info) 
+                       style_function=lambda x: {
+                           'fillColor': info['Fill_Color'],
+                           'color': info['Line_Color'],
+                           'weight': info['Line_Width'],
+                           'fillOpacity': info['Fill_Opacity']
+                       },
+                       tooltip=folium.GeoJsonTooltip(
+                           fields=list(dataframe_geo.columns.intersection(info['Data_Names'])),
+                           aliases=info['Label_Names'],
+                           localize=True
+                       )
+                       ).add_to(feature_info)
         feature_info.add_to(self.map)
+
     def _layer_control(self):
         folium.LayerControl(collapsed=True).add_to(self.map)
 
     def show(self):
         return self.map
 
-
-    def _geotiff(self,info):
+    def _geotiff(self, info):
         from rasterio.windows import Window
         import rasterio as rs
         from pyproj import Proj
@@ -618,29 +586,28 @@ class InteractiveMap:
             col_min, row_min = ~t * (xmin, ymin)
             col_max, row_max = ~t * (xmax, ymax)
 
-
-            window = Window.from_slices(rows=(floor(row_max), ceil(row_min)),cols=(floor(col_min), ceil(col_max)))
+            window = Window.from_slices(rows=(floor(row_max), ceil(row_min)), cols=(floor(col_min), ceil(col_max)))
             transform = guard_transform(dataset.transform)
-            return window,rs.windows.bounds(window, transform)
+            return window, rs.windows.bounds(window, transform)
 
         dataset = rs.open(info['filename'])
         resamplingFactor = info['Resampling_Factor']
-        window=None
+        window = None
         bnds = [[dataset.bounds[1], dataset.bounds[0]], [dataset.bounds[3], dataset.bounds[2]]]
-        trying =True
+        trying = True
         indx = 1
         while trying:
             try:
                 img = folium.raster_layers.ImageOverlay(
-                    name="{} - Band {}".format(info['Name'],indx),
-                    image=dataset.read(indx,window=window)[::resamplingFactor,::resamplingFactor],
+                    name="{} - Band {}".format(info['Name'], indx),
+                    image=dataset.read(indx, window=window)[::resamplingFactor, ::resamplingFactor],
                     bounds=bnds,
                     opacity=info['Opacity'],
                     mercator_project=True,
                     pixelated=False,
-                    show = info['Show']
+                    show=info['Show']
                 )
                 img.add_to(self.map)
             except:
-                trying=False
-            indx+=1
+                trying = False
+            indx += 1

--- a/polar_route/transients.py
+++ b/polar_route/transients.py
@@ -10,8 +10,9 @@ class Icebergs:
         Simple module for processing and updating the iceberg locations through time determining the location on the
         same time interval asvthe PolarRoute Mesh, and returning the indices of the iceberg locations.
     """
-    def __init__(self,cellGrid,object_locations):
-        self.cellGrid         = cellGrid
+
+    def __init__(self, cellGrid, object_locations):
+        self.cellGrid = cellGrid
         self.object_locations = object_locations
 
     def _cellGridResample(self):
@@ -19,7 +20,7 @@ class Icebergs:
             Function that takes the super resolution of the iceberg tracking and resamples on the temporal sampling of
             the PolarRoute Mesh structure
         """
-    
+
     def _physicsModel(self):
         """
             The physics based model describing the updating of the iceberg locations.
@@ -36,8 +37,3 @@ class Icebergs:
             Given the Mesh and the iceberg locations forward propagate to determine the expected locations given a
             physics model describing the dynamics of the icebergs.
         '''
-
-        
-
-
-

--- a/polar_route/utils.py
+++ b/polar_route/utils.py
@@ -80,5 +80,3 @@ def setup_logging(func,
         logging.getLogger("urllib3").setLevel(logging.WARNING)
         return parsed_args
     return wrapper
-
-

--- a/polar_route/vessel_performance.py
+++ b/polar_route/vessel_performance.py
@@ -44,6 +44,7 @@ class VesselPerformance:
             vessel_params (dict): The vessel specific information contained within the config
 
     """
+
     def __init__(self, mesh_json):
         """
             Constructs the VesselPerformance class from a given input mesh in json format which is then modified
@@ -158,7 +159,7 @@ class VesselPerformance:
 
         froude = speed / np.sqrt(gravity * area / 100 * thickness)
         resistance = 0.5 * kparam * (froude ** bparam) * density * beam * thickness * (speed ** 2) * (
-                    (area / 100) ** nparam)
+            (area / 100) ** nparam)
         return resistance
 
     def inverse_resistance(self, area, thickness, density):
@@ -184,7 +185,7 @@ class VesselPerformance:
         gravity = 9.81  # m/s-2
 
         vexp = 2 * force_limit / (kparam * density * beam * thickness * ((area / 100) ** nparam) * (
-                    gravity * thickness * area / 100) ** -(bparam / 2))
+            gravity * thickness * area / 100) ** -(bparam / 2))
 
         vms = vexp ** (1 / (2.0 + bparam))
         speed = vms * (18. / 5.)  # convert from m/s to km/h
@@ -226,7 +227,7 @@ class VesselPerformance:
             Method to calculate the speed based on the sea ice concentration using a simple toy model.
         """
         self.mesh_df['speed'] = (1 - np.sqrt(self.mesh_df['SIC'] / 100)) * \
-                                        self.vessel_params['Speed']
+            self.vessel_params['Speed']
 
     @timed_call
     def fuel(self):

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -10,6 +10,7 @@ import json
 from polar_route.mesh import Mesh
 from polar_route.vessel_performance import VesselPerformance
 
+
 def test_cellbox_count(mesh_a, mesh_b):
     """
         Test if two provided meshes contain the same number of cellboxes
@@ -28,6 +29,7 @@ def test_cellbox_count(mesh_a, mesh_b):
 
     assert(cellbox_count_a == cellbox_count_b), \
         f"Incorrect number of cellboxes in new mesh. Expected :{cellbox_count_a}, got: {cellbox_count_b}"
+
 
 def test_cellbox_ids(mesh_a, mesh_b):
     """
@@ -56,8 +58,9 @@ def test_cellbox_ids(mesh_a, mesh_b):
     missing_a_ids = list(mesh_b_ids - mesh_a_ids)
     missing_b_ids = list(mesh_a_ids - mesh_b_ids)
 
-    assert(indxed_a.keys()  == indxed_b.keys()), \
+    assert(indxed_a.keys() == indxed_b.keys()), \
         f"Mismatch in cellbox IDs. ID's {missing_a_ids} have appeared in the new mesh. ID's {missing_b_ids} are missing from the new mesh"
+
 
 def test_cellbox_values(mesh_a, mesh_b):
     """
@@ -100,8 +103,9 @@ def test_cellbox_values(mesh_a, mesh_b):
                         mismatch_values.append(key)
                         mismatch_cellboxes[cellbox_a['id']] = mismatch_values
 
-    assert(len(mismatch_cellboxes) == 0) , \
+    assert(len(mismatch_cellboxes) == 0), \
         f"Values in <{len(mismatch_cellboxes.keys())}> cellboxes in the new mesh have changed. The changes cellboxes are: {mismatch_cellboxes}"
+
 
 def test_cellbox_attributes(mesh_a, mesh_b):
     """
@@ -131,6 +135,7 @@ def test_cellbox_attributes(mesh_a, mesh_b):
     assert(mesh_a_attributes == mesh_b_attributes), \
         f"Mismatch in cellbox attributes. Attributes {missing_a_attributes} have appeared in the new mesh. Attributes {missing_b_attributes} are missing in the new mesh"
 
+
 def test_neighbour_graph_count(graph_a, graph_b):
     """
 
@@ -145,6 +150,7 @@ def test_neighbour_graph_count(graph_a, graph_b):
 
     assert(graph_a_count == graph_b_count), \
         f"Incorrect number of nodes in neighbour graph. Expected: <{graph_a_count}> nodes, got: <{graph_b_count}> nodes."
+
 
 def test_neighbour_graph_ids(graph_a, graph_b):
     """
@@ -161,8 +167,9 @@ def test_neighbour_graph_ids(graph_a, graph_b):
     missing_a_keys = list(graph_b_ids - graph_a_ids)
     missing_b_keys = list(graph_a_ids - graph_b_ids)
 
-    assert(graph_a_ids == graph_b_ids) , \
+    assert(graph_a_ids == graph_b_ids), \
         f"Mismatch in neighbour graph nodes. <{len(missing_a_keys)}> nodes  have appeared in the new neighbour graph. <{len(missing_b_keys)}> nodes  are missing from the new neighbour graph."
+
 
 def test_neighbour_graph_values(graph_a, graph_b):
     """
@@ -176,7 +183,7 @@ def test_neighbour_graph_values(graph_a, graph_b):
     mismatch_neighbors = dict()
 
     for node in graph_a.keys():
-        # Prevent crashing if node not found. 
+        # Prevent crashing if node not found.
         # This will be detected by 'test_neighbour_graph_ids'.
         if node in graph_b.keys():
             neighbours_a = graph_a[node]
@@ -187,6 +194,7 @@ def test_neighbour_graph_values(graph_a, graph_b):
 
     assert(len(mismatch_neighbors) == 0), \
         f"Mismatch in neighbour graph neighbours. <{len(mismatch_neighbors.keys())}> nodes have changed in new mesh."
+
 
 def main():
     """
@@ -265,8 +273,7 @@ def main():
         print("test_neighbour_graph_values : failed")
         print("    " + str(warning))
     print("tests complete!")
-  
+
 
 if __name__ == "__main__":
     main()
-    


### PR DESCRIPTION
Resolves: [gh-42 Linting/PEP8 adherence](https://github.com/antarctica/PolarRoute/issues/42)

Used autopep8 ensure code adheres to pep8 standards. Autopep8 command run:` autopep8 --exit-code -r -i -a -a --ignore E721,E722,E501 .`

This ignores some of rules that made large and possibly unwanted changes to the code. These rules could be looked into to see if the changes are wanted by the owners of the code. Ignored rules:
E721 - Use "isinstance()" instead of comparing types directly.
E722 - Fix bare except.
E501 - Try to make lines fit within --max-line-length characters.

autopep8 documentation can be found [here](https://github.com/hhatto/autopep8)