### PR TITLE
Fix Namespace object being passed into route_planner.py to str which …

### DIFF
--- a/polar_route/cli.py
+++ b/polar_route/cli.py
@@ -119,7 +119,7 @@ def optimise_routes_cli():
     else: 
         logging.info("outputting full mesh to {}".format(args.output))
 
-    rp = RoutePlanner(args.info,args.route_arg,args.waypoints)
+    rp = RoutePlanner(args.info.name, args.route_info.name, args.waypoints.name)
     rp.compute_routes()
     info_dijkstra = rp.to_json()
     rp.compute_smoothed_routes()


### PR DESCRIPTION
Fixed issue where Namespace object passed into route_planner.py, now string of filename is passed for RoutePlanner to read from. Also fixed typo 'args.route_arg' to 'args.route_info'