### PR TITLE
Reg test fix

### DIFF
--- a/tests/regression_tests/test_regression.py
+++ b/tests/regression_tests/test_regression.py
@@ -444,7 +444,7 @@ def compare_cellbox_values(mesh_a, mesh_b):
 
                     # Compare values
                     
-                    if value_a != value_b:
+                    if str(value_a) != str(value_b):
                         mismatch_values.append(key)
                         mismatch_cellboxes[cellbox_a['id']] = mismatch_values
 

--- a/tests/regression_tests/test_regression.py
+++ b/tests/regression_tests/test_regression.py
@@ -12,33 +12,33 @@ from polar_route.vessel_performance import VesselPerformance
 
 #File locations of all vessel performance meshes to be recaculated for regression testing.
 TEST_VESSEL_MESHES = [
-    './example_meshes/Vessel_Performance_Meshes/add_vehicle.output2013_4_80.json',
+    # './example_meshes/Vessel_Performance_Meshes/add_vehicle.output2013_4_80.json',
     './example_meshes/Vessel_Performance_Meshes/add_vehicle.output2017_6_80.json',
-    './example_meshes/Vessel_Performance_Meshes/add_vehicle.output2019_6_80.json'
+    # './example_meshes/Vessel_Performance_Meshes/add_vehicle.output2019_6_80.json'
 ]
 
 #File locations of all enviromental meshes to be recaculated for regression testing.
 TEST_ENV_MESHES = [
-    './example_meshes/Enviromental_Meshes/create_mesh.output2013_4_80.json',
+    # './example_meshes/Enviromental_Meshes/create_mesh.output2013_4_80.json',
     './example_meshes/Enviromental_Meshes/create_mesh.output2016_6_80.json',
-    './example_meshes/Enviromental_Meshes/create_mesh.output2019_6_80.json'
+    # './example_meshes/Enviromental_Meshes/create_mesh.output2019_6_80.json'
 ]
 
 TEST_GRADIENT_MESHES = [
-    './example_meshes/Abstract_Environmental_Meshes/vgrad_n201_vT_mesh.json',
-    './example_meshes/Abstract_Environmental_Meshes/hgrad_n201_vF_mesh.json'
+    # './example_meshes/Abstract_Environmental_Meshes/vgrad_n201_vT_mesh.json',
+    # './example_meshes/Abstract_Environmental_Meshes/hgrad_n201_vF_mesh.json'
 ]
 
 TEST_CHECKERBOARD_MESHES = [
-    './example_meshes/Abstract_Environmental_Meshes/checkerboard_n201_gw2.5_gh2.5_mesh.json',
-    './example_meshes/Abstract_Environmental_Meshes/checkerboard_n201_gw5_gh2.5_mesh.json',
-    './example_meshes/Abstract_Environmental_Meshes/checkerboard_n201_gw6_gh3_mesh.json'
+    # './example_meshes/Abstract_Environmental_Meshes/checkerboard_n201_gw2.5_gh2.5_mesh.json',
+    # './example_meshes/Abstract_Environmental_Meshes/checkerboard_n201_gw5_gh2.5_mesh.json',
+    # './example_meshes/Abstract_Environmental_Meshes/checkerboard_n201_gw6_gh3_mesh.json'
 ]
 
 TEST_CIRCLE_MESHES = [
-    './example_meshes/Abstract_Environmental_Meshes/circle_n201_r2_cy-62.5_cx-60.0_mesh.json',
-    './example_meshes/Abstract_Environmental_Meshes/cornercirclesplit_n201_r3_cy-65_cx-70_mesh.json',
-    './example_meshes/Abstract_Environmental_Meshes/cornercirclenosplit_n201_r3_cy-65_cx-70_mesh.json'
+    # './example_meshes/Abstract_Environmental_Meshes/circle_n201_r2_cy-62.5_cx-60.0_mesh.json',
+    # './example_meshes/Abstract_Environmental_Meshes/cornercirclesplit_n201_r3_cy-65_cx-70_mesh.json',
+    # './example_meshes/Abstract_Environmental_Meshes/cornercirclenosplit_n201_r3_cy-65_cx-70_mesh.json'
 ]
 
 @pytest.fixture(scope='session', autouse=False, params=TEST_ENV_MESHES)
@@ -443,7 +443,8 @@ def compare_cellbox_values(mesh_a, mesh_b):
                         value_a = cellbox_a[key]
 
                     # Compare values
-                    if not(value_a == value_b) and not(np.isnan(value_a) or np.isnan(value_b)):
+                    
+                    if value_a != value_b:
                         mismatch_values.append(key)
                         mismatch_cellboxes[cellbox_a['id']] = mismatch_values
 

--- a/tests/regression_tests/test_regression.py
+++ b/tests/regression_tests/test_regression.py
@@ -12,33 +12,33 @@ from polar_route.vessel_performance import VesselPerformance
 
 #File locations of all vessel performance meshes to be recaculated for regression testing.
 TEST_VESSEL_MESHES = [
-    # './example_meshes/Vessel_Performance_Meshes/add_vehicle.output2013_4_80.json',
+    './example_meshes/Vessel_Performance_Meshes/add_vehicle.output2013_4_80.json',
     './example_meshes/Vessel_Performance_Meshes/add_vehicle.output2017_6_80.json',
-    # './example_meshes/Vessel_Performance_Meshes/add_vehicle.output2019_6_80.json'
+    './example_meshes/Vessel_Performance_Meshes/add_vehicle.output2019_6_80.json'
 ]
 
 #File locations of all enviromental meshes to be recaculated for regression testing.
 TEST_ENV_MESHES = [
-    # './example_meshes/Enviromental_Meshes/create_mesh.output2013_4_80.json',
+    './example_meshes/Enviromental_Meshes/create_mesh.output2013_4_80.json',
     './example_meshes/Enviromental_Meshes/create_mesh.output2016_6_80.json',
-    # './example_meshes/Enviromental_Meshes/create_mesh.output2019_6_80.json'
+    './example_meshes/Enviromental_Meshes/create_mesh.output2019_6_80.json'
 ]
 
 TEST_GRADIENT_MESHES = [
-    # './example_meshes/Abstract_Environmental_Meshes/vgrad_n201_vT_mesh.json',
-    # './example_meshes/Abstract_Environmental_Meshes/hgrad_n201_vF_mesh.json'
+    './example_meshes/Abstract_Environmental_Meshes/vgrad_n201_vT_mesh.json',
+    './example_meshes/Abstract_Environmental_Meshes/hgrad_n201_vF_mesh.json'
 ]
 
 TEST_CHECKERBOARD_MESHES = [
-    # './example_meshes/Abstract_Environmental_Meshes/checkerboard_n201_gw2.5_gh2.5_mesh.json',
-    # './example_meshes/Abstract_Environmental_Meshes/checkerboard_n201_gw5_gh2.5_mesh.json',
-    # './example_meshes/Abstract_Environmental_Meshes/checkerboard_n201_gw6_gh3_mesh.json'
+    './example_meshes/Abstract_Environmental_Meshes/checkerboard_n201_gw2.5_gh2.5_mesh.json',
+    './example_meshes/Abstract_Environmental_Meshes/checkerboard_n201_gw5_gh2.5_mesh.json',
+    './example_meshes/Abstract_Environmental_Meshes/checkerboard_n201_gw6_gh3_mesh.json'
 ]
 
 TEST_CIRCLE_MESHES = [
-    # './example_meshes/Abstract_Environmental_Meshes/circle_n201_r2_cy-62.5_cx-60.0_mesh.json',
-    # './example_meshes/Abstract_Environmental_Meshes/cornercirclesplit_n201_r3_cy-65_cx-70_mesh.json',
-    # './example_meshes/Abstract_Environmental_Meshes/cornercirclenosplit_n201_r3_cy-65_cx-70_mesh.json'
+    './example_meshes/Abstract_Environmental_Meshes/circle_n201_r2_cy-62.5_cx-60.0_mesh.json',
+    './example_meshes/Abstract_Environmental_Meshes/cornercirclesplit_n201_r3_cy-65_cx-70_mesh.json',
+    './example_meshes/Abstract_Environmental_Meshes/cornercirclenosplit_n201_r3_cy-65_cx-70_mesh.json'
 ]
 
 @pytest.fixture(scope='session', autouse=False, params=TEST_ENV_MESHES)


### PR DESCRIPTION
Fixing a issue with the regression tests when comparing NaN values. 

Previously when comparing two attributes of a cellbox in `compare_cellbox_values()`, if either of the attributes where NaN the comparison was skipped without reporting an error. Now if either of the attributes are NaN, it only skips without reporting an error if the other attribute is also NaN.

The full regression test suite has been run and has passed for this pull request:
![image](https://user-images.githubusercontent.com/96304883/217274381-0929635d-c2aa-433e-aece-545658e4b8ec.png)


A full log of the regression tests outputs is available: 
[pytest_dump.txt](https://github.com/antarctica/PolarRoute/files/10676147/pytest_dump.txt)
