### PR TITLE
Enabling dataloaders to read from folder

### DIFF
--- a/docs/source/sections/Dataloaders/overview.rst
+++ b/docs/source/sections/Dataloaders/overview.rst
@@ -93,5 +93,16 @@ These are the templates to be used when implementing new dataloaders into PolarR
 They have been split into two seperate categories: Scalar and Vector, detailed in `Dataloader Types`_.
 The abstract classes generalise the methods used by each dataloader type to produce outputs
 that the Environmental Mesh can retrieve via the  :ref:`dataloader interface<dataloader-interface>`. 
-They are flexible in that they can store and process data as both :code:`pandas.DataFrame`'s or 
-:code:`xarray.Dataset`'s.
+They are flexible in that they can store and process data as both :code:`xarray.Dataset`'s or 
+:code:`pandas.DataFrame`'s (and by extension, :code:`dask.DataFrames`'s). 
+When creating your own, :code:`dask` and :code:`xarray` should be utilised as much as possible to 
+reduce memory consumption.
+
+Both abstract base classes define the :code:`__init__()` function to have the following process:
+
+#. Read in params from config
+#. Add params from :code:`self.add_params()`, defined by user when creating a dataloader
+#. Downsample data if required and if loaded as :code:`xarray.Dataset`
+#. Reproject data if required
+#. Trim datapoints to initial boundary
+#. Rename data column name if defined in params

--- a/docs/source/sections/Dataloaders/scalar/index.rst
+++ b/docs/source/sections/Dataloaders/scalar/index.rst
@@ -20,7 +20,7 @@ functionality that would be needed to manipulate the data to work
 with the mesh. When creating a new dataloader, the user must define
 how to open the data files, and what methods are required to manipulate
 the data into a standard format. More details are provided on the 
-:ref:`abstractScalar doc page<abstract-scalar-dataloader>`
+:ref:`abstractScalar doc page<abstract-scalar-dataloader>`.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Scalar Dataloader Examples
@@ -33,80 +33,41 @@ Below is a simple example of how to load in a NetCDF file::
     import logging
 
     class MyDataLoader(ScalarDataLoader):
-        def __init__(self, bounds, params):
-            # Creates a class attribute for all keys in params
-            for key, val in params.items():
-                logging.debug(
-                    f"Reading in {key}:{value} (dtype={type(value)}) from params"
-                    )
-                setattr(self, key, val)
-            
-            # Import data from file
-            self.data = self.import_data(bounds)
-
-            # Retrieve data name from variable name in NetCDF
-            self.data_name = self.get_data_col_name()
-
-            logging.info(f"Successfully loaded {self.data_name} from {self.file}")
-            
+      
         def import_data(self, bounds):
             logging.debug("Importing my data...")
             # Open Dataset
-            logging.debug(f"- Opening file {self.file}")
-            data = xr.open_dataset(self.file)
+            data = xr.open_mfdataset(self.files)
 
             # Rename coordinate columns to 'lat', 'long', 'time' if they aren't already
             data = data.rename({'lon':'long'})
 
             # Limit to initial boundary
-            data = data.sel(lat=slice(bounds.get_lat_min(),bounds.get_lat_max()))
-            data = data.sel(long=slice(bounds.get_long_min(),bounds.get_long_max()))
-            data = data.sel(time=slice(bounds.get_time_min(),bounds.get_time_max()))
+            data = self.trim_data(bounds, data=data)
 
             return data
 
 
-Sometimes the data needs to be reprojected if it is not initially in mercator 
-projection. It may also need to be downsampled if the dataset is very large. 
-The following code handles both of these cases::
+Sometimes there are parameters that are constant for a data source, but are not 
+constant for all data sources. Default values may be defined either in the
+dataloader factory, or within the dataloader itself. Below is an example of 
+setting default parameters for reprojection of a dataset::
 
     class MyDataLoader(ScalarDataLoader):
-        def __init__(self, bounds, params):
-            # Creates a class attribute for all keys in params
-            for key, val in params.items():
-                logging.debug(
-                    f"Reading in {key}:{value} (dtype={type(value)}) from config params"
-                    )
-                setattr(self, key, val)
-            
-            # Import data from file
-            self.data = self.import_data(bounds)
-            # Downsampling data by 'downsample_factors' defined in config params
-            self.data = self.downsample()
-            # Reprojecting dataset from EPSG:3412 to 'EPSG:4326'. 
-            # Coordinate names 'x', 'y' will be replaced with 'long', 'lat' 
-            self.data = self.reproject( in_proj  = 'EPSG:3412',
-                                        out_proj = 'EPSG:4326',
-                                        x_col    = 'x',
-                                        y_col    = 'y')
+        def add_params(self, params):
+            # Define projection of dataset being imported
+            params['in_proj'] = 'EPSG:3412'
+            # Define projection required by output 
+            params['out_proj'] = 'EPSG:4326' # default is EPSG:4326, so strictly
+                                             # speaking this line is not necessary
 
-            # Limit to initial boundary. 
-            # Note: Reprojection converts data to pandas dataframe
-            idx = self.get_datapoints(bounds).index
-            self.data = self.data.loc[idx]
-            
-            # Manually overwriting data name
-            self.data_name = "my_variable"
-            self.data = self.set_data_col_name(self.data_name)
-
-            logging.info(f"Successfully loaded {self.data_name} from {self.file}")
+            # Coordinates in dataset that will be reprojected into long/lat
+            params['x_col'] = 'x' # Becomes 'long'
+            params['y_col'] = 'y' # Becomes 'lat'
             
         def import_data(self, bounds):
-            logging.debug("Importing my data...")
-            
             # Open Dataset
-            logging.debug(f"- Opening file {self.file}")
-            data = xr.open_dataset(self.file)
+            data = xr.open_mfdataset(self.files)
 
             # Can't easily determine bounds of data in wrong projection, so skipping for now
             return data

--- a/docs/source/sections/Dataloaders/vector/index.rst
+++ b/docs/source/sections/Dataloaders/vector/index.rst
@@ -40,22 +40,6 @@ NetCDF file::
     import logging
 
     class MyDataLoader(VectorDataLoader):
-        def __init__(self, bounds, params):
-            # Creates a class attribute for all keys in params
-            for key, val in params.items():
-                logging.debug(
-                    f"Reading in {key}:{value} (dtype={type(value)}) from params"
-                    )
-                setattr(self, key, val)
-            
-            # Import data from file
-            self.data = self.import_data(bounds)
-
-            # Retrieve data name from variable name in NetCDF
-            self.data_name = self.get_data_col_name()
-
-            logging.info(f"Successfully loaded {self.data_name} from {self.file}")
-            
         def import_data(self, bounds):
             logging.debug("Importing my data...")
             # Open Dataset
@@ -66,53 +50,31 @@ NetCDF file::
             data = data.rename({'lon':'long'})
 
             # Limit to initial boundary
-            data = data.sel(lat=slice(bounds.get_lat_min(),bounds.get_lat_max()))
-            data = data.sel(long=slice(bounds.get_long_min(),bounds.get_long_max()))
-            data = data.sel(time=slice(bounds.get_time_min(),bounds.get_time_max()))
+            data = self.trim_data(bounds, data=data)
 
             return data
 
 
-Similar to scalar data loaders, sometimes the data needs to be reprojected 
-if it is not initially in mercator projection. It may also need to be downsampled 
-if the dataset is very large. The following code handles both of these cases::
+Similar to scalar data loaders, sometimes there are parameters that are constant 
+for a data source, but are not constant for all data sources. Default values may 
+be defined either in the dataloader factory, or within the dataloader itself. 
+Below is an example of setting default parameters for reprojection of a dataset::
 
     class MyDataLoader(ScalarDataLoader):
-        def __init__(self, bounds, params):
-            # Creates a class attribute for all keys in params
-            for key, val in params.items():
-                logging.debug(
-                    f"Reading in {key}:{value} (dtype={type(value)}) from config params"
-                    )
-                setattr(self, key, val)
-            
-            # Import data from file
-            self.data = self.import_data(bounds)
-            # Downsampling data by 'downsample_factors' defined in config params
-            self.data = self.downsample()
-            # Reprojecting dataset from EPSG:3412 to 'EPSG:4326'. 
-            # Coordinate names 'x', 'y' will be replaced with 'long', 'lat' 
-            self.data = self.reproject( in_proj  = 'EPSG:3412',
-                                        out_proj = 'EPSG:4326',
-                                        x_col    = 'x',
-                                        y_col    = 'y')
+        def add_params(self, params):
+            # Define projection of dataset being imported
+            params['in_proj'] = 'EPSG:3412'
+            # Define projection required by output 
+            params['out_proj'] = 'EPSG:4326' # default is EPSG:4326, so strictly
+                                             # speaking this line is not necessary
 
-            # Limit to initial boundary. 
-            # Note: Reprojection converts data to pandas dataframe
-            idx = self.get_datapoints(bounds).index
-            self.data = self.data.loc[idx]
-            
-            # Manually overwriting data names for each vector component
-            self.data_name = "v_x,v_y"
-            self.data = self.set_data_col_name(self.data_name)
-            logging.info(f"Successfully loaded {self.data_name} from {self.file}")
+            # Coordinates in dataset that will be reprojected into long/lat
+            params['x_col'] = 'x' # Becomes 'long'
+            params['y_col'] = 'y' # Becomes 'lat'
             
         def import_data(self, bounds):
-            logging.debug("Importing my data...")
-            
             # Open Dataset
-            logging.debug(f"- Opening file {self.file}")
-            data = xr.open_dataset(self.file)
+            data = xr.open_mfdataset(self.file)
 
             # Can't easily determine bounds of data in wrong projection, so skipping for now
             return data

--- a/polar_route/dataloaders/factory.py
+++ b/polar_route/dataloaders/factory.py
@@ -21,7 +21,7 @@ from polar_route.dataloaders.vector.vectorGRF import VectorGRFDataLoader
 from polar_route.dataloaders.scalar.density import DensityDataLoader
 from polar_route.dataloaders.scalar.thickness import ThicknessDataLoader
 
-
+from glob import glob
 
 
 class DataLoaderFactory:
@@ -56,17 +56,14 @@ class DataLoaderFactory:
         
         dataloader_requirements = {
             # Scalar
-            'scalar_csv':  (ScalarCSVDataLoader, ['file']),
-            'binary_grf':  (ScalarGRFDataLoader, []),
-            'scalar_grf':  (ScalarGRFDataLoader, []),
-            'amsr':        (AMSRDataLoader, ['file', 'hemisphere']),
-            'amsr_folder': (AMSRDataLoader, ['folder', 'hemisphere']),
-            'bsose_sic':   (BSOSESeaIceDataLoader, ['file']),
-            'bsose_depth': (BSOSEDepthDataLoader, ['file']),
-            'baltic_sic':  (BalticSeaIceDataLoader, ['file']),
-            'gebco':       (GEBCODataLoader, ['file']),
-            'icenet':      (IceNetDataLoader, ['file']),
-            'modis':       (MODISDataLoader, ['file']),
+            'scalarcsv':(ScalarCSVDataLoader, ['files']),
+            'amsr':        (AMSRDataLoader, ['files', 'hemisphere']),
+            'bsose_sic':   (BSOSESeaIceDataLoader, ['files']),
+            'bsose_depth': (BSOSEDepthDataLoader, ['files']),
+            'baltic_sic':  (BalticSeaIceDataLoader, ['files']),
+            'gebco':       (GEBCODataLoader, ['files']),
+            'icenet':      (IceNetDataLoader, ['files']),
+            'modis':       (MODISDataLoader, ['files']),
             # TODO Make these LUT dataloaders
             'thickness': (ThicknessDataLoader, []),
             'density':   (DensityDataLoader, []),
@@ -76,13 +73,13 @@ class DataLoaderFactory:
             'gradient':     (ShapeDataLoader, ['shape', 'nx', 'ny', 'vertical']),
             'checkerboard': (ShapeDataLoader, ['shape', 'nx', 'ny', 'gridsize']),
             # Vector
-            'vectorcsv':        (VectorCSVDataLoader, ['file']),
-            'vector_grf':       (VectorGRFDataLoader, []),
-            'baltic_currents':  (BalticCurrentDataLoader, ['file']),
-            'era5_wind':        (ERA5WindDataLoader, ['file']),
-            'northsea_currents':(NorthSeaCurrentDataLoader, ['file']),
-            'oras5_currents':   (ORAS5CurrentDataLoader, ['file_u', 'file_v']),
-            'sose':             (SOSEDataLoader, ['file'])
+            'vectorcsv':        (VectorCSVDataLoader, ['files']),
+            'baltic_currents':  (BalticCurrentDataLoader, ['files']),
+            'era5_wind':        (ERA5WindDataLoader, ['files']),
+            'northsea_currents':(NorthSeaCurrentDataLoader, ['files']),
+            # TODO make it run from 'files'
+            'oras5_currents':   (ORAS5CurrentDataLoader, ['files']),
+            'sose':             (SOSEDataLoader, ['files'])
             # Lookup Table
             # TODO
         }
@@ -134,7 +131,12 @@ class DataLoaderFactory:
         if 'min_dp' not in params:
             params['min_dp'] = min_dp
             
-        # Set defaults for abstract shape generators
+        if 'file' in params:
+            params['files'] = [params['file']]
+        elif 'folder' in params:
+            params['files'] = sorted(glob(params['folder']))
+            
+        # Set defaults for abstract data generators
         if name in ['circle', 'checkerboard', 'gradient']:
             params = self.set_default_shape_params(name, params)
         

--- a/polar_route/dataloaders/factory.py
+++ b/polar_route/dataloaders/factory.py
@@ -22,6 +22,7 @@ from polar_route.dataloaders.scalar.density import DensityDataLoader
 from polar_route.dataloaders.scalar.thickness import ThicknessDataLoader
 
 from glob import glob
+import os
 
 
 class DataLoaderFactory:
@@ -56,33 +57,33 @@ class DataLoaderFactory:
         
         dataloader_requirements = {
             # Scalar
-            'scalarcsv':(ScalarCSVDataLoader, ['files']),
-            'amsr':        (AMSRDataLoader, ['files', 'hemisphere']),
-            'amsr_folder': (AMSRDataLoader, ['folder', 'hemisphere']),
-            'bsose_sic':   (BSOSESeaIceDataLoader, ['files']),
-            'bsose_depth': (BSOSEDepthDataLoader, ['files']),
-            'baltic_sic':  (BalticSeaIceDataLoader, ['files']),
-            'gebco':       (GEBCODataLoader, ['files']),
-            'icenet':      (IceNetDataLoader, ['files']),
-            'modis':       (MODISDataLoader, ['files']),
-            # TODO Make these LUT dataloaders
-            'thickness': (ThicknessDataLoader, []),
-            'density':   (DensityDataLoader, []),
+            'scalar_csv':   (ScalarCSVDataLoader, ['files']),
+            'scalar_grf':   (ScalarGRFDataLoader, []),
+            'binary_grf':   (ScalarGRFDataLoader,[]),
+            'amsr':         (AMSRDataLoader, ['files', 'hemisphere']),
+            'bsose_sic':    (BSOSESeaIceDataLoader, ['files']),
+            'bsose_depth':  (BSOSEDepthDataLoader, ['files']),
+            'baltic_sic':   (BalticSeaIceDataLoader, ['files']),
+            'gebco':        (GEBCODataLoader, ['files']),
+            'icenet':       (IceNetDataLoader, ['files']),
+            'modis':        (MODISDataLoader, ['files']),
+            'thickness':    (ThicknessDataLoader, []),
+            'density':      (DensityDataLoader, []),
             # Scalar - Abstract shapes
             'circle':       (ShapeDataLoader, ['shape', 'nx', 'ny', 'radius', 'centre']),
             'square':       (ShapeDataLoader, ['shape', 'nx', 'ny', 'side_length', 'centre']),
             'gradient':     (ShapeDataLoader, ['shape', 'nx', 'ny', 'vertical']),
             'checkerboard': (ShapeDataLoader, ['shape', 'nx', 'ny', 'gridsize']),
             # Vector
-            'vectorcsv':        (VectorCSVDataLoader, ['files']),
+            'vector_csv':       (VectorCSVDataLoader, ['files']),
+            'vector_grf':       (VectorGRFDataLoader, []),
             'baltic_currents':  (BalticCurrentDataLoader, ['files']),
             'era5_wind':        (ERA5WindDataLoader, ['files']),
             'northsea_currents':(NorthSeaCurrentDataLoader, ['files']),
             # TODO make it run from 'files'
             'oras5_currents':   (ORAS5CurrentDataLoader, ['files']),
             'sose':             (SOSEDataLoader, ['files'])
-            # Lookup Table
-            # TODO
+
         }
         # If name is recognised as a dataloader
         if name in dataloader_requirements:
@@ -149,7 +150,8 @@ class DataLoaderFactory:
         if 'file' in params:
             params['files'] = [params['file']]
         elif 'folder' in params:
-            params['files'] = sorted(glob(params['folder']+'*'))
+            folder = os.path.join(params['folder'], '') # Adds trailing slash if non-existant
+            params['files'] = sorted(glob(folder+'*'))
             
         # Set defaults for abstract data generators
         if name in ['circle', 'checkerboard', 'gradient']:
@@ -261,33 +263,3 @@ class DataLoaderFactory:
                 params['vec_y'] = 'vC'
                 
         return params
-
-if __name__ == '__main__':
-    from polar_route.mesh_generation.boundary import Boundary
-    
-    bounds = Boundary([-65,-60],[-70,-50],['2013-03-01', '2013-03-14'])
-    
-    if True:
-        params = {
-            'file': '/home/habbot/Documents/Work/PolarRoute/datastore/bathymetry/GEBCO/gebco_2022_n-40.0_s-90.0_w-140.0_e0.0.nc',
-            'aggregate_type': 'MAX',
-            "downsample_factors": [
-                                        5,
-                                        5
-                                    ],
-        }
-        gebco = DataLoaderFactory().get_dataloader('gebco', bounds, params)
-    
-    if True:
-        params = {
-            'folder':'/home/habbot/Documents/Work/PolarRoute/datastore/sic/amsr_south/',
-            'hemisphere': 'south'
-        }
-        amsr = DataLoaderFactory().get_dataloader('amsr', bounds, params)
-        
-    if True:
-        params = {}
-        splitting_conds = {'threshold': 1000, 'upper_bound':0.9, 'lower_bound':0.1}
-        density = DataLoaderFactory().get_dataloader('density', bounds, params)
-        # print(density.get_hom_condition(bounds, splitting_conds))
-    print()

--- a/polar_route/dataloaders/factory.py
+++ b/polar_route/dataloaders/factory.py
@@ -58,6 +58,7 @@ class DataLoaderFactory:
             # Scalar
             'scalarcsv':(ScalarCSVDataLoader, ['files']),
             'amsr':        (AMSRDataLoader, ['files', 'hemisphere']),
+            'amsr_folder': (AMSRDataLoader, ['folder', 'hemisphere']),
             'bsose_sic':   (BSOSESeaIceDataLoader, ['files']),
             'bsose_depth': (BSOSEDepthDataLoader, ['files']),
             'baltic_sic':  (BalticSeaIceDataLoader, ['files']),
@@ -118,6 +119,8 @@ class DataLoaderFactory:
                 Dictionary of attributes the dataloader will require, 
                 completed with default values if not provided in config.
         '''
+        # Save dataloader name in params
+        params['dataloader_name'] = name
         
         if 'downsample_factors' not in params:
             params['downsample_factors'] = (1,1)
@@ -131,10 +134,22 @@ class DataLoaderFactory:
         if 'min_dp' not in params:
             params['min_dp'] = min_dp
             
+        if 'in_proj' not in params:
+            params['in_proj'] = 'EPSG:4326'
+            
+        if 'out_proj' not in params:
+            params['out_proj'] = 'EPSG:4326'
+            
+        if 'x_col' not in params:
+            params['x_col'] = 'lat'
+
+        if 'y_col' not in params:
+            params['y_col'] = 'long'
+            
         if 'file' in params:
             params['files'] = [params['file']]
         elif 'folder' in params:
-            params['files'] = sorted(glob(params['folder']))
+            params['files'] = sorted(glob(params['folder']+'*'))
             
         # Set defaults for abstract data generators
         if name in ['circle', 'checkerboard', 'gradient']:
@@ -250,7 +265,29 @@ class DataLoaderFactory:
 if __name__ == '__main__':
     from polar_route.mesh_generation.boundary import Boundary
     
-    bounds = Boundary([-10,10],[-10,10],['2000-01-01', '2000-01-31'])
+    bounds = Boundary([-65,-60],[-70,-50],['2013-03-01', '2013-03-14'])
     
-    scalar = DataLoaderFactory().get_dataloader('scalar_grf', bounds, {})
+    if True:
+        params = {
+            'file': '/home/habbot/Documents/Work/PolarRoute/datastore/bathymetry/GEBCO/gebco_2022_n-40.0_s-90.0_w-140.0_e0.0.nc',
+            'aggregate_type': 'MAX',
+            "downsample_factors": [
+                                        5,
+                                        5
+                                    ],
+        }
+        gebco = DataLoaderFactory().get_dataloader('gebco', bounds, params)
+    
+    if True:
+        params = {
+            'folder':'/home/habbot/Documents/Work/PolarRoute/datastore/sic/amsr_south/',
+            'hemisphere': 'south'
+        }
+        amsr = DataLoaderFactory().get_dataloader('amsr', bounds, params)
+        
+    if True:
+        params = {}
+        splitting_conds = {'threshold': 1000, 'upper_bound':0.9, 'lower_bound':0.1}
+        density = DataLoaderFactory().get_dataloader('density', bounds, params)
+        # print(density.get_hom_condition(bounds, splitting_conds))
     print()

--- a/polar_route/dataloaders/scalar/abstractScalar.py
+++ b/polar_route/dataloaders/scalar/abstractScalar.py
@@ -424,10 +424,10 @@ class ScalarDataLoader(DataLoaderInterface):
         
         # If no reprojection to do
         if in_proj == out_proj:
-            logging.debug("- self.reproject() called but don't need to")
+            logging.debug("\tself.reproject() called but don't need to")
             return self.data
         else:
-            logging.info(f"- Reprojecting data from {in_proj} to {out_proj}")
+            logging.info(f"\tReprojecting data from {in_proj} to {out_proj}")
         
         # Choose appropriate method of reprojection based on data type
         if type(self.data) == type(pd.DataFrame()):

--- a/polar_route/dataloaders/scalar/abstractScalar.py
+++ b/polar_route/dataloaders/scalar/abstractScalar.py
@@ -34,7 +34,7 @@ class ScalarDataLoader(DataLoaderInterface):
                 Name of scalar variable. Must be the column name if self.data
                 is pd.DataFrame. Must be variable if self.data is xr.Dataset
         '''
-        print(f"Initialising {params['dataloader_name']} dataloader")
+        logging.info(f"Initialising {params['dataloader_name']} dataloader")
         
         # Translates parameters from config input to desired inputs
         params = self.add_params(params)

--- a/polar_route/dataloaders/scalar/abstractScalar.py
+++ b/polar_route/dataloaders/scalar/abstractScalar.py
@@ -12,10 +12,9 @@ class ScalarDataLoader(DataLoaderInterface):
     '''
     Abstract class for all scalar Datasets.
     '''
-    @abstractmethod
-    def __init__(self, bounds, params, min_dp):
+    def __init__(self, bounds, params):
         '''
-        User defined. This is where large-scale operations are performed, 
+        This is where large-scale operations are performed, 
         such as importing data, downsampling, reprojecting, and renaming 
         variables
         
@@ -25,9 +24,7 @@ class ScalarDataLoader(DataLoaderInterface):
             params (dict): 
                 Values needed by dataloader to initialise. Unique to each
                 dataloader
-            min_dp (int): 
-                Minimum datapoints required to get homogeneity condition
-                
+
         Attributes:
             self.data (pd.DataFrame or xr.Dataset): 
                 Data stored by dataloader to use when called upon by the mesh.
@@ -37,7 +34,46 @@ class ScalarDataLoader(DataLoaderInterface):
                 Name of scalar variable. Must be the column name if self.data
                 is pd.DataFrame. Must be variable if self.data is xr.Dataset
         '''
-        pass
+        print(f"Initialising {params['dataloader_name']} dataloader")
+        
+        # Translates parameters from config input to desired inputs
+        params = self.add_params(params)
+        # Creates a class attribute for all keys in params
+        for key, val in params.items():
+            setattr(self, key, val)
+            
+        # Read in and manipulate data to standard form
+        if 'files' in params:
+            logging.info('\tReading in files:')
+            for file in self.files:
+                logging.info(f'\t\t{file}')
+        self.data = self.import_data(bounds)
+        # If need to downsample data
+        self.data = self.downsample()
+        # If need to reproject data
+        if self.in_proj != self.out_proj:
+            self.data = self.reproject(
+                                in_proj  = self.in_proj,
+                                out_proj = self.out_proj,
+                                x_col    = self.x_col,
+                                y_col    = self.y_col
+                                )
+        # Cut dataset down to initial boundary
+        logging.info(
+            "\tTrimming data to initial boundary: {min} to {max}".format(
+                min=(bounds.get_lat_min(), bounds.get_long_min()),
+                max=(bounds.get_lat_max(), bounds.get_long_max())
+            ))
+        self.data = self.trim_datapoints(bounds)
+
+        # Get data name from column name if not set in params
+        if self.data_name is None:
+            logging.debug('- Setting self.data_name from column name')
+            self.data_name = self.get_data_col_name()
+        # or if set in params, set col name to data name
+        else:
+            logging.debug(f'- Setting data column name to {self.data_name}')
+            self.data = self.set_data_col_name(self.data_name)
 
     @abstractmethod
     def import_data(self, bounds):
@@ -59,6 +95,86 @@ class ScalarDataLoader(DataLoaderInterface):
                 Downsampling and reprojecting happen in __init__() method
         '''
         pass
+    
+    def add_params(self, params):
+        '''
+        Provides option to add parameters before dataloader initialised,
+        useful for translating params from config to specific default 
+        parameters for dataloader. Does nothing by default, but user can
+        overload to add to specific dataloader
+        
+        Args:
+            params (dict): 
+                Dictionary holding keys and values that will be turned into 
+                object attributes
+        
+        Returns:
+            dict:
+                Params dictionary with addition of translated key/value pairs
+        '''
+        return params
+    
+    def trim_datapoints(self, bounds, data=None):
+        '''
+        Trims datapoints from self.data within boundary defined by 'bounds'.
+        self.data can be pd.DataFrame or xr.Dataset
+        
+        Args:
+            bounds (Boundary): Limits of lat/long/time to select data from
+
+        Returns:
+            pd.DataFrame or xr.Dataset: 
+                Trimmed dataset in same format as self.data
+        '''
+        def trim_datapoints_from_df(data, bounds):
+            '''
+            Extracts data from a pd.DataFrame
+            '''
+            # Mask off any positions not within spatial bounds
+            mask = (data['lat']  > bounds.get_lat_min())  & \
+                   (data['lat']  <= bounds.get_lat_max())  & \
+                   (data['long'] > bounds.get_long_min()) & \
+                   (data['long'] <= bounds.get_long_max())
+            # Mask with time if time column exists
+            if 'time' in data.columns:
+                mask &= (data['time'] >= bounds.get_time_min()) & \
+                        (data['time'] <= bounds.get_time_max())
+                        
+            # Return column of data from within bounds
+            return data.loc[mask]
+        
+        def trim_datapoints_from_xr(data, bounds):
+            '''
+            Extracts data from a xr.Dataset
+            '''
+            # Select data region within spatial bounds
+            # TODO make sure boundaries act same as df
+            data = data.sel(lat=slice(bounds.get_lat_min(),  bounds.get_lat_max() ))
+            data = data.sel(long=slice(bounds.get_long_min(), bounds.get_long_max()))
+            # Select data region within temporal bounds if time exists as a coordinate
+            if 'time' in data.coords.keys():
+                data = data.sel(time=slice(bounds.get_time_min(),  bounds.get_time_max()))
+
+            # Return column of data from within bounds
+            return data
+        
+        # If no specific data passed in, default to entire dataset
+        if data is None:
+            data = self.data
+        
+        # Skip trimming if data already completely within bounds
+        if data.lat.min() >  bounds.get_lat_min() and \
+           data.lat.max() <= bounds.get_lat_max() and \
+           data.long.min() >  bounds.get_long_min() and \
+           data.long.max() <= bounds.get_long_max():
+            logging.debug('Data is already trimmed to bounds!')
+            return data
+        
+        if type(data) == type(pd.DataFrame()):
+            return trim_datapoints_from_df(data, bounds)
+        elif type(data) == type(xr.Dataset()):
+            return trim_datapoints_from_xr(data, bounds)
+
 
     def get_dp_from_coord(self, long=None, lat=None, return_coords=False):
         '''
@@ -114,10 +230,8 @@ class ScalarDataLoader(DataLoaderInterface):
             return get_dp_from_coord_df(self.data, data_name, long, lat, return_coords)
         elif type(self.data) == type(xr.Dataset()):
             return get_dp_from_coord_xr(self.data, data_name, long, lat, return_coords)
-        
-        
 
-    def get_datapoints(self, bounds, return_coords=False):
+    def get_datapoints(self, bounds, return_coords=False, data=None):
         '''
         Extracts datapoints from self.data within boundary defined by 'bounds'.
         self.data can be pd.DataFrame or xr.Dataset
@@ -127,67 +241,35 @@ class ScalarDataLoader(DataLoaderInterface):
             return_coords (boolean): 
                 Flag to determine if coordinates are provided for each 
                 datapoint found. Default is False.
-                            
             
         Returns:
             pd.DataFrame: 
                 Column of data values within selected region. If return_coords
                 is true, also returns with coordinate columns 
         '''
-        def get_datapoints_from_df(data, name, bounds, return_coords):
-            '''
-            Extracts data from a pd.DataFrame
-            '''
-            # Mask off any positions not within spatial bounds
-            mask = (data['lat']  > bounds.get_lat_min())  & \
-                   (data['lat']  <= bounds.get_lat_max())  & \
-                   (data['long'] > bounds.get_long_min()) & \
-                   (data['long'] <= bounds.get_long_max())
-            # Mask with time if time column exists
-            if 'time' in data.columns:
-                mask &= (data['time'] >= bounds.get_time_min()) & \
-                        (data['time'] <= bounds.get_time_max())
-                        
-            # Include lat/long/time if requested
-            if return_coords: columns = list(data.columns)
-            else:             columns = [name]
-            
-            # Return column of data from within bounds
-            return data.loc[mask][columns]
-        
-        def get_datapoints_from_xr(data, name, bounds, return_coords):
-            '''
-            Extracts data from a xr.Dataset
-            '''
-            # Select data region within spatial bounds
-            # TODO make sure boundaries act same as df
-            data = data.sel(lat=slice(bounds.get_lat_min(),  bounds.get_lat_max() ))
-            data = data.sel(long=slice(bounds.get_long_min(), bounds.get_long_max()))
-            # Select data region within temporal bounds if time exists as a coordinate
-            if 'time' in data.coords.keys():
-                data = data.sel(time=slice(bounds.get_time_min(),  bounds.get_time_max()))
-            # Cast as a pd.DataFrame
+        if data is None:
+            data = self.data
+        # Cast to dataframe for output
+        if type(data) == type(xr.Dataset()):
+            data = self.trim_datapoints(bounds, data=data)
+            # Cast to dataframe
             data = data.to_dataframe().reset_index().dropna()
             
-            # to trims inclusive edges from a slice taken with xarray
-            data = get_datapoints_from_df(data, name, bounds, return_coords)
-            
-            # Include lat/long/time if requested
-            if return_coords: columns = list(data.columns)
-            else:             columns = [name]
-            
-            # Return column of data from within bounds
-            return data[columns]
-            
-        # Choose which method to retrieve data based on input type
+        # Trim to boundary specified
+        data = self.trim_datapoints(bounds, data=data)
+
+        # Retrieve data column name
         if hasattr(self, 'data_name'): data_name = self.data_name
         else:                          data_name = self.get_data_col_name()
         
-        if type(self.data) == type(pd.DataFrame()):
-            return get_datapoints_from_df(self.data, data_name, bounds, return_coords)
-        elif type(self.data) == type(xr.Dataset()):
-            return get_datapoints_from_xr(self.data, data_name, bounds, return_coords)
-
+        # Include lat/long/time if requested
+        if return_coords: columns = list(data.columns)
+        else:             columns = [data_name]
+        
+        
+        # Return column of data from within bounds
+        return data[columns]
+        
     def get_value(self, bounds, agg_type=None, skipna=True):
         '''
         Retrieve aggregated value from within bounds
@@ -275,7 +357,6 @@ class ScalarDataLoader(DataLoaderInterface):
         
         # Retrieve datapoints to analyse
         dps = self.get_datapoints(bounds)[self.data_name]
-        
         # If not enough datapoints
         if len(dps) < self.min_dp: hom_type = "MIN"
         # Otherwise, extract the homogeneity condition
@@ -319,7 +400,7 @@ class ScalarDataLoader(DataLoaderInterface):
         def reproject_df(data, in_proj, out_proj, x_col, y_col):
             '''
             Reprojects a pandas dataframe
-            '''
+            '''            
             # Do the reprojection
             x, y = Transformer\
                     .from_crs(CRS(in_proj), CRS(out_proj), always_xy=True)\
@@ -347,6 +428,7 @@ class ScalarDataLoader(DataLoaderInterface):
             return self.data
         else:
             logging.info(f"- Reprojecting data from {in_proj} to {out_proj}")
+        
         # Choose appropriate method of reprojection based on data type
         if type(self.data) == type(pd.DataFrame()):
             return reproject_df(self.data, in_proj, out_proj, x_col, y_col)

--- a/polar_route/dataloaders/scalar/amsr.py
+++ b/polar_route/dataloaders/scalar/amsr.py
@@ -1,8 +1,6 @@
 from polar_route.dataloaders.scalar.abstractScalar import ScalarDataLoader
 from datetime import datetime
 
-import logging
-import glob
 import xarray as xr
 class AMSRDataLoader(ScalarDataLoader):
     

--- a/polar_route/dataloaders/scalar/balticSeaIce.py
+++ b/polar_route/dataloaders/scalar/balticSeaIce.py
@@ -1,6 +1,5 @@
 from polar_route.dataloaders.scalar.abstractScalar import ScalarDataLoader
 
-import logging
 import xarray as xr
 
 

--- a/polar_route/dataloaders/scalar/balticSeaIce.py
+++ b/polar_route/dataloaders/scalar/balticSeaIce.py
@@ -5,35 +5,6 @@ import xarray as xr
 
 
 class BalticSeaIceDataLoader(ScalarDataLoader):
-    def __init__(self, bounds, params):
-        '''
-        Initialises Baltic Sea Ice  dataset. Does no post-processing
-        
-       Args:
-            bounds (Boundary): 
-                Initial boundary to limit the dataset to
-            params (dict):
-                Dictionary of {key: value} pairs. Keys are attributes 
-                this dataloader requires to function
-        '''
-        logging.info("Initalising Baltic Sea Ice dataloader")
-        # Creates a class attribute for all keys in params
-        for key, val in params.items():
-            logging.debug(f"self.{key}={val} (dtype={type(val)}) from params")
-            setattr(self, key, val)
-        
-        # Import data
-        self.data = self.import_data(bounds)
-        
-        # Get data name from column name if not set in params
-        if self.data_name is None:
-            logging.debug('- Setting self.data_name from column name')
-            self.data_name = self.get_data_col_name()
-        # or if set in params, set col name to data name
-        else:
-            logging.debug(f'- Setting data column name to {self.data_name}')
-            self.data = self.set_data_col_name(self.data_name)
-        
     def import_data(self, bounds):
         '''
         Reads in data from a Baltic Sea Ice NetCDF file. 
@@ -47,9 +18,8 @@ class BalticSeaIceDataLoader(ScalarDataLoader):
                 Baltic Sea Ice dataset within limits of bounds. 
                 Dataset has coordinates 'lat', 'long', and variable 'SIC'         
         '''
-        logging.info(f"- Opening file {self.file}")
         # Open Dataset
-        data = xr.open_dataset(self.file)
+        data = xr.open_mfdataset(self.files)
         # Change column names
         data = data.rename({'ice_concentration': 'SIC',
                             'lon': 'long'})
@@ -57,13 +27,7 @@ class BalticSeaIceDataLoader(ScalarDataLoader):
         data = data['SIC'].to_dataset()
         # Reverse order of lat as array goes from max to min
         data = data.reindex(lat=data.lat[::-1])
-        # Limit to initial boundary
-        logging.info('- Limiting to initial bounds')
-        data = data.sel(lat=slice(bounds.get_lat_min(),
-                                  bounds.get_lat_max()))
-        data = data.sel(long=slice(bounds.get_long_min(),
-                                   bounds.get_long_max()))
-        data = data.sel(time=slice(bounds.get_time_min(), 
-                                   bounds.get_time_max()))
+        # Trim to initial datapoints
+        data = self.trim_datapoints(bounds, data=data)
         
         return data

--- a/polar_route/dataloaders/scalar/bsoseDepth.py
+++ b/polar_route/dataloaders/scalar/bsoseDepth.py
@@ -1,7 +1,5 @@
 from polar_route.dataloaders.scalar.abstractScalar import ScalarDataLoader
 
-import logging
-
 import xarray as xr
 
 class BSOSEDepthDataLoader(ScalarDataLoader):

--- a/polar_route/dataloaders/scalar/bsoseDepth.py
+++ b/polar_route/dataloaders/scalar/bsoseDepth.py
@@ -5,35 +5,6 @@ import logging
 import xarray as xr
 
 class BSOSEDepthDataLoader(ScalarDataLoader):
-    def __init__(self, bounds, params):
-        '''
-        Initialises BSOSE depth dataset. Does no post-processing
-        
-       Args:
-            bounds (Boundary): 
-                Initial boundary to limit the dataset to
-            params (dict):
-                Dictionary of {key: value} pairs. Keys are attributes 
-                this dataloader requires to function
-        '''
-        logging.info("Initalising BSOSE Depth dataloader")
-        # Creates a class attribute for all keys in params
-        for key, val in params.items():
-            logging.debug(f"self.{key}={val} (dtype={type(val)}) from params")
-            setattr(self, key, val)
-        
-        # Import data
-        self.data = self.import_data(bounds)
-        
-        # Get data name from column name if not set in params
-        if self.data_name is None:
-            logging.debug('- Setting self.data_name from column name')
-            self.data_name = self.get_data_col_name()
-        # or if set in params, set col name to data name
-        else:
-            logging.debug(f'- Setting data column name to {self.data_name}')
-            self.data = self.set_data_col_name(self.data_name)
-        
     def import_data(self, bounds):
         '''
         Reads in data from a BSOSE Depth NetCDF file. 
@@ -48,23 +19,15 @@ class BSOSEDepthDataLoader(ScalarDataLoader):
                 BSOSE Depth dataset within limits of bounds. 
                 Dataset has coordinates 'lat', 'long', and variable 'elevation'
         '''
-        logging.info(f"- Opening file {self.file}")
         # Open Dataset
-        data = xr.open_dataset(self.file)
+        data = xr.open_mfdataset(self.files)
         # Change column names
         data = data.rename({'Depth': 'elevation',
                             'YC': 'lat',
                             'XC': 'long'})
         # Change domain of dataset from [0:360) to [-180:180)
         data = data.assign_coords(long=((da.lon + 180) % 360) - 180)
-        
-        # Limit to initial boundary
-        logging.info('- Limiting to initial bounds')
-        data = data.sel(lat=slice(bounds.get_lat_min(),
-                                  bounds.get_lat_max()))
-        data = data.sel(long=slice(bounds.get_long_min(),
-                                   bounds.get_long_max()))
-        data = data.sel(time=slice(bounds.get_time_min(), 
-                                   bounds.get_time_max()))
+        # Trim to initial datapoints
+        data = self.trim_datapoints(bounds, data=data)
         
         return data

--- a/polar_route/dataloaders/scalar/bsoseSeaIce.py
+++ b/polar_route/dataloaders/scalar/bsoseSeaIce.py
@@ -26,7 +26,7 @@ class BSOSESeaIceDataLoader(ScalarDataLoader):
         '''
         logging.info(f"- Opening file {self.file}")
         # Open Dataset
-        data = xr.open_dataset(self.file)
+        data = xr.open_mfdataset(self.file)
         # Change column names
         data = data.rename({'SIarea': 'SIC',
                             'YC': 'lat',

--- a/polar_route/dataloaders/scalar/bsoseSeaIce.py
+++ b/polar_route/dataloaders/scalar/bsoseSeaIce.py
@@ -5,35 +5,6 @@ import logging
 import xarray as xr
 
 class BSOSESeaIceDataLoader(ScalarDataLoader):
-    def __init__(self, bounds, params):
-        '''
-        Initialises BSOSE Sea Ice  dataset. Does no post-processing
-        
-       Args:
-            bounds (Boundary): 
-                Initial boundary to limit the dataset to
-            params (dict):
-                Dictionary of {key: value} pairs. Keys are attributes 
-                this dataloader requires to function
-        '''
-        logging.info("Initalising BSOSE Sea Ice dataloader")
-        # Creates a class attribute for all keys in params
-        for key, val in params.items():
-            logging.debug(f"self.{key}={val} (dtype={type(val)}) from params")
-            setattr(self, key, val)
-        
-        # Import data
-        self.data = self.import_data(bounds)
-        
-        # Get data name from column name if not set in params
-        if self.data_name is None:
-            logging.debug('- Setting self.data_name from column name')
-            self.data_name = self.get_data_col_name()
-        # or if set in params, set col name to data name
-        else:
-            logging.debug(f'- Setting data column name to {self.data_name}')
-            self.data = self.set_data_col_name(self.data_name)
-        
     def import_data(self, bounds):
         '''
         Reads in data from a BSOSE Sea Ice NetCDF file. 
@@ -65,15 +36,8 @@ class BSOSESeaIceDataLoader(ScalarDataLoader):
         data = data.assign_coords(long=((data.long + 180) % 360) - 180)
         # Sort the 'long' axis so that sel() will work
         data = data.sortby('long')
-        
-        # Limit to initial boundary
-        logging.info('- Limiting to initial bounds')
-        data = data.sel(lat=slice(bounds.get_lat_min(),
-                                  bounds.get_lat_max()))
-        data = data.sel(long=slice(bounds.get_long_min(),
-                                   bounds.get_long_max()))
-        data = data.sel(time=slice(bounds.get_time_min(), 
-                                   bounds.get_time_max()))
+        # Trim to initial datapoints
+        data = self.trim_datapoints(bounds, data=data)
 
         if hasattr(self, 'units'):
             logging.info(f'- Changing units of data to {self.units}')

--- a/polar_route/dataloaders/scalar/density.py
+++ b/polar_route/dataloaders/scalar/density.py
@@ -1,46 +1,13 @@
 from polar_route.dataloaders.scalar.abstractScalar import ScalarDataLoader
 from polar_route.utils import date_range
 
-
 from datetime import datetime
 import logging
-
 
 import numpy as np
 import xarray as xr
 
 class DensityDataLoader(ScalarDataLoader):
-    def __init__(self, bounds, params):
-        '''
-        Initialises density dataset. Initialises from values in a lookup table
-        This will eventually be deprecated and replaced with a 
-        'Lookup Table Dataloader'
-        
-       Args:
-            bounds (Boundary): 
-                Initial boundary to limit the dataset to
-            params (dict):
-                Dictionary of {key: value} pairs. Keys are attributes 
-                this dataloader requires to function
-        '''
-        logging.info("Initalising Sea Ice Density dataloader")
-        # Creates a class attribute for all keys in params
-        for key, val in params.items():
-            logging.debug(f"self.{key}={val} (dtype={type(val)}) from params")
-            setattr(self, key, val)
-        
-        # Import data
-        self.data = self.import_data(bounds)
-        
-        # Get data name from column name if not set in params
-        if self.data_name is None:
-            logging.debug('- Setting self.data_name from column name')
-            self.data_name = self.get_data_col_name()
-        # or if set in params, set col name to data name
-        else:
-            logging.debug(f'- Setting data column name to {self.data_name}')
-            self.data = self.set_data_col_name(self.data_name)
-        
     def import_data(self, bounds):
         '''
         Creates a simulated dataset of sea ice density based on 
@@ -106,9 +73,10 @@ class DensityDataLoader(ScalarDataLoader):
             to_dataframe().\
             reset_index().\
             set_index(['lat', 'long', 'time'])
-        
+        # Cast to xr.Dataset for faster processing
         density_xr = density_df.to_xarray()
-
+        # Clear memory of now unused dataframe
         del density_df
+        # No need to trim data, as was defined by bounds
 
         return density_xr

--- a/polar_route/dataloaders/scalar/gebco.py
+++ b/polar_route/dataloaders/scalar/gebco.py
@@ -4,42 +4,9 @@ import logging
 import xarray as xr
 
 class GEBCODataLoader(ScalarDataLoader):
-    def __init__(self, bounds, params):
-        '''
-        Initialises GEBCO dataset, 
-        downsamples (if downsample_factors specified in params)
-        and sets variable name (if data_name specified in params)
-        
-        Args:
-            bounds (Boundary): 
-                Initial boundary to limit the dataset to
-            params (dict):
-                Dictionary of {key: value} pairs. Keys are attributes 
-                this dataloader requires to function
-        '''
-        logging.info("Initalising GEBCO dataloader")
-        # Creates a class attribute for all keys in params
-        for key, val in params.items():
-            logging.debug(f"self.{key}={val} (dtype={type(val)}) from params")
-            setattr(self, key, val)
-        
-        # Import data
-        self.data = self.import_data(bounds)
-        # Downsample if specified in params
-        self.data = self.downsample()
-        
-        # Get data name from column name if not set in params
-        if self.data_name is None:
-            logging.debug('- Setting self.data_name from column name')
-            self.data_name = self.get_data_col_name()
-        # or if set in params, set col name to data name
-        else:
-            logging.debug(f'- Setting data column name to {self.data_name}')
-            self.data = self.set_data_col_name(self.data_name)
-        
     def import_data(self, bounds):
         '''
-        Reads in data from a GEBCO NetCDF file. Renames coordinates to
+        Reads in data from GEBCO NetCDF files. Renames coordinates to
         'lat' and 'long'.
         
         Args:
@@ -50,13 +17,11 @@ class GEBCODataLoader(ScalarDataLoader):
                 GEBCO dataset within limits of bounds. 
                 Dataset has coordinates 'lat', 'long', and variable 'elevation'         
         '''
-        # Open Dataset
-        logging.info(f"- Opening file {self.file}")
-        data = xr.open_dataset(self.file)
+        # Import data from files defined in config
+        data = xr.open_mfdataset(self.files)
+        # Rename columns to standard format
         data = data.rename({'lon':'long'})
+        # Trim to initial datapoints
+        data = self.trim_datapoints(bounds, data=data)
         
-        # Limit to initial boundary
-        logging.info('- Limiting to initial bounds')
-        data = data.sel(lat=slice(bounds.get_lat_min(),bounds.get_lat_max()))
-        data = data.sel(long=slice(bounds.get_long_min(),bounds.get_long_max()))
         return data

--- a/polar_route/dataloaders/scalar/icenet.py
+++ b/polar_route/dataloaders/scalar/icenet.py
@@ -31,7 +31,7 @@ class IceNetDataLoader(ScalarDataLoader):
         # Retrieve list of dates from filenames
         # assumes file names are in the format 
         # <hemisphere>_daily_forecast.<YYYY-MM-DD>.nc
-        file_dates = {datetime.strptime(file.split('.')[1], '%YYYY-%m-%d'): file 
+        file_dates = {datetime.strptime(file.split('.')[1], '%Y-%m-%d'): file 
                       for file in self.files}
 
         # Find closest date prior to min_time
@@ -51,7 +51,7 @@ class IceNetDataLoader(ScalarDataLoader):
         assert time_range < timedelta(days=max_leadtime),\
             f'Time boundary too large! Forecast only runs for max of {max_leadtime} days'
         
-        assert closest_date + timedelta(days=max_leadtime) < max_time,\
+        assert closest_date + timedelta(days=max_leadtime) > max_time,\
             'Time boundary runs beyond max forecast date!'
         
         logging.info(f"- Searching for closest date prior to {bounds.get_time_min()}")

--- a/polar_route/dataloaders/scalar/modis.py
+++ b/polar_route/dataloaders/scalar/modis.py
@@ -4,36 +4,7 @@ import logging
 import xarray as xr
 
 
-class MODISDataLoader(ScalarDataLoader):
-    def __init__(self, bounds, params):
-        '''
-        Initialises MODIS dataset. Does no post-processing
-        
-       Args:
-            bounds (Boundary): 
-                Initial boundary to limit the dataset to
-            params (dict):
-                Dictionary of {key: value} pairs. Keys are attributes 
-                this dataloader requires to function
-        '''
-        logging.info("Initalising MODIS dataloader")
-        # Creates a class attribute for all keys in params
-        for key, val in params.items():
-            logging.debug(f"self.{key}={val} (dtype={type(val)}) from params")
-            setattr(self, key, val)
-        
-        # Import data
-        self.data = self.import_data(bounds)
-        
-        # Get data name from column name if not set in params
-        if self.data_name is None:
-            logging.debug('- Setting self.data_name from column name')
-            self.data_name = self.get_data_col_name()
-        # or if set in params, set col name to data name
-        else:
-            logging.debug(f'- Setting data column name to {self.data_name}')
-            self.data = self.set_data_col_name(self.data_name)
-        
+class MODISDataLoader(ScalarDataLoader):        
     def import_data(self, bounds):
         '''
         Reads in data from a MODIS NetCDF file. 
@@ -55,14 +26,7 @@ class MODISDataLoader(ScalarDataLoader):
 
         # Set areas obscured by cloud to NaN values
         data = data.where(data.cloud != 1, drop=True)
-        
-        logging.info('- Limiting to initial bounds')
-        # Limit to initial boundary
-        data = data.sel(lat=slice(bounds.get_lat_min(),
-                                  bounds.get_lat_max()))
-        data = data.sel(long=slice(bounds.get_long_min(),
-                                   bounds.get_long_max()))
-        data = data.sel(time=slice(bounds.get_time_min(), 
-                                   bounds.get_time_max()))
+        # Trim to initial datapoints
+        data = self.trim_datapoints(bounds, data=data)
         
         return data

--- a/polar_route/dataloaders/scalar/modis.py
+++ b/polar_route/dataloaders/scalar/modis.py
@@ -20,7 +20,7 @@ class MODISDataLoader(ScalarDataLoader):
         '''
         logging.info(f"- Opening file {self.file}")
         # Open Dataset
-        data = xr.open_dataset(self.file)
+        data = xr.open_mfdataset(self.file)
         # Change column name
         data = data.rename({'iceArea': 'SIC'})
 

--- a/polar_route/dataloaders/scalar/scalarCSV.py
+++ b/polar_route/dataloaders/scalar/scalarCSV.py
@@ -1,38 +1,9 @@
 from polar_route.dataloaders.scalar.abstractScalar import ScalarDataLoader
 
 import logging
-import pandas as pd
+import dask as dd
 
 class ScalarCSVDataLoader(ScalarDataLoader):
-    def __init__(self, bounds, params):
-        '''
-        Initialises dataset from CSV file. Does no post-processing
-        
-       Args:
-            bounds (Boundary): 
-                Initial boundary to limit the dataset to
-            params (dict):
-                Dictionary of {key: value} pairs. Keys are attributes 
-                this dataloader requires to function
-        '''
-        logging.info("Initalising Scalar CSV dataloader")
-        # Creates a class attribute for all keys in params
-        for key, val in params.items():
-            logging.debug(f"self.{key}={val} (dtype={type(val)}) from params")
-            setattr(self, key, val)
-        
-        # Import data
-        self.data = self.import_data(bounds)
-        
-        # Get data name from column name if not set in params
-        if self.data_name is None:
-            logging.debug('- Setting self.data_name from column name')
-            self.data_name = self.get_data_col_name()
-        # or if set in params, set col name to data name
-        else:
-            logging.debug(f'- Setting data column name to {self.data_name}')
-            self.data = self.set_data_col_name(self.data_name)
-        
     def import_data(self, bounds):
         '''
         Reads in data from a CSV file. 
@@ -46,19 +17,9 @@ class ScalarCSVDataLoader(ScalarDataLoader):
                 Dataset has coordinates 'lat', 'long', potentially 'time',
                 and variable defined by column heading in csv file
         '''
-
-        logging.info(f"- Opening file {self.file}")
-        # Load in a csv file
-        data = pd.read_csv(self.file)
-
-        logging.info('- Limiting to initial bounds')
-        # Limit to within boundaries
-        data = data[data['long'].between(bounds.get_long_min(), 
-                                         bounds.get_long_max())]
-        data = data[data['lat'].between(bounds.get_lat_min(), 
-                                        bounds.get_lat_max())]
-        if 'time' in data.columns:
-            data = data[data['time'].between(bounds.get_time_min(), 
-                                            bounds.get_time_max())]
+        # Read in data
+        data = dd.read_csv(self.files)
+        # Trim to initial datapoints
+        data = self.trim_datapoints(bounds, data=data)
         
         return data

--- a/polar_route/dataloaders/scalar/scalarCSV.py
+++ b/polar_route/dataloaders/scalar/scalarCSV.py
@@ -1,6 +1,5 @@
 from polar_route.dataloaders.scalar.abstractScalar import ScalarDataLoader
 
-import logging
 import dask as dd
 
 class ScalarCSVDataLoader(ScalarDataLoader):

--- a/polar_route/dataloaders/scalar/scalarGRF.py
+++ b/polar_route/dataloaders/scalar/scalarGRF.py
@@ -6,35 +6,6 @@ import pandas as pd
 import numpy as np
 
 class ScalarGRFDataLoader(ScalarDataLoader):
-    def __init__(self, bounds, params):
-        '''
-        Generates a dataset using a gaussian random field
-        
-        Args:
-            bounds (Boundary): 
-                Initial boundary to limit the dataset to
-            params (dict):
-                Dictionary of {key: value} pairs. Keys are attributes 
-                this dataloader requires to function
-        '''
-        logging.info("Initalising Scalar CSV dataloader")
-        # Creates a class attribute for all keys in params
-        for key, val in params.items():
-            logging.debug(f"self.{key}={val} (dtype={type(val)}) from params")
-            setattr(self, key, val)
-        
-        # Import data
-        self.data = self.import_data(bounds)
-        
-        # Get data name from column name if not set in params
-        if self.data_name is None:
-            logging.debug('- Setting self.data_name from column name')
-            self.data_name = self.get_data_col_name()
-        # or if set in params, set col name to data name
-        else:
-            logging.debug(f'- Setting data column name to {self.data_name}')
-            self.data = self.set_data_col_name(self.data_name)
-        
     def import_data(self, bounds):
         '''
         Creates data in the form of a Gaussian Random Field

--- a/polar_route/dataloaders/scalar/shape.py
+++ b/polar_route/dataloaders/scalar/shape.py
@@ -5,35 +5,6 @@ import pandas as pd
 import numpy as np
 
 class ShapeDataLoader(ScalarDataLoader):
-    def __init__(self, bounds, params):
-        '''
-        Initialises abstract shape datasets.
-                
-       Args:
-            bounds (Boundary): 
-                Initial boundary to limit the dataset to
-            params (dict):
-                Dictionary of {key: value} pairs. Keys are attributes 
-                this dataloader requires to function
-        '''
-        logging.info("Initalising abstract shape dataloader")
-        # Creates a class attribute for all keys in params
-        for key, val in params.items():
-            logging.debug(f"self.{key}={val} (dtype={type(val)}) from params")
-            setattr(self, key, val)
-        
-        # Import data
-        self.data = self.import_data(bounds)
-        
-        # Get data name from column name if not set in params
-        if self.data_name is None:
-            logging.debug('- Setting self.data_name from column name')
-            self.data_name = self.get_data_col_name()
-        # or if set in params, set col name to data name
-        else:
-            logging.debug(f'- Setting data column name to {self.data_name}')
-            self.data = self.set_data_col_name(self.data_name)
-    
     def import_data(self, bounds):
         '''
         Generates data in the form of an abstract shape, such as circle,
@@ -62,7 +33,8 @@ class ShapeDataLoader(ScalarDataLoader):
         data['time'] = bounds.get_time_min()
 
         data_xr = data.set_index(['lat', 'long', 'time']).to_xarray()
-    
+        # No need to trim data, as was defined by bounds
+
         return data_xr
     
     def gen_circle(self, bounds):

--- a/polar_route/dataloaders/scalar/shape.py
+++ b/polar_route/dataloaders/scalar/shape.py
@@ -45,7 +45,7 @@ class ShapeDataLoader(ScalarDataLoader):
             Args:
                 bounds (Boundary): Limits of lat/long to generate within
         """
-        logging.info(f"- Setting up boundary of dataset")
+        logging.info("\tSetting up boundary of dataset")
         # Generate rows
         self.lat  = np.linspace(bounds.get_lat_min(), bounds.get_lat_max(), self.ny)    
         # Generate cols
@@ -61,14 +61,14 @@ class ShapeDataLoader(ScalarDataLoader):
                                   self.ny))
         x = np.linspace(bounds.get_long_min(), bounds.get_long_max(), self.nx)
 
-        logging.info(f"- Creating mask of circle")
+        logging.info("\tCreating mask of circle")
         # Create a 2D-array with distance from defined centre
         dist_from_centre = np.sqrt((x-c_x)**2 + (y-c_y)**2)
         # Turn this into a mask of values within radius
         mask = dist_from_centre <= self.radius
         # Set up empty dataframe to populate with dummy data
         dummy_df = pd.DataFrame(columns = ['lat', 'long', 'dummy_data'])
-        logging.info("- Generating dataset")
+        logging.info("\tGenerating dataset")
         # For each combination of lat/long
         for i in range(self.ny):
             for j in range(self.nx):
@@ -92,7 +92,7 @@ class ShapeDataLoader(ScalarDataLoader):
             Args:
                 bounds (Boundary): Limits of lat/long to generate within
         """
-        logging.info(f"- Setting up boundary of dataset")
+        logging.info("\tSetting up boundary of dataset")
         # Generate rows
         self.lat  = np.linspace(bounds.get_lat_min(), 
                                 bounds.get_lat_max(), 
@@ -102,7 +102,7 @@ class ShapeDataLoader(ScalarDataLoader):
                                 bounds.get_long_max(),
                                 self.nx)
         
-        logging.info(f"- Creating gradient of values")
+        logging.info("\tCreating gradient of values")
         #Create 1D gradient
         if self.vertical:   gradient = np.linspace(0,1,self.ny)
         else:               gradient = np.linspace(0,1,self.nx)
@@ -130,7 +130,7 @@ class ShapeDataLoader(ScalarDataLoader):
             Args:
                 bounds (Boundary): Limits of lat/long to generate within
         """
-        logging.info(f"- Setting up boundary of dataset")
+        logging.info("\tSetting up boundary of dataset")
         # Generate rows
         self.lat  = np.linspace(bounds.get_lat_min(), 
                                 bounds.get_lat_max(), 

--- a/polar_route/dataloaders/scalar/thickness.py
+++ b/polar_route/dataloaders/scalar/thickness.py
@@ -7,37 +7,6 @@ import numpy as np
 import xarray as xr
 
 class ThicknessDataLoader(ScalarDataLoader):
-    def __init__(self, bounds, params):
-        '''
-        Initialises thickness dataset. Initialises from values in a lookup table
-        This will eventually be deprecated and replaced with a 
-        'Lookup Table Dataloader'
-        
-       Args:
-            bounds (Boundary): 
-                Initial boundary to limit the dataset to
-            params (dict):
-                Dictionary of {key: value} pairs. Keys are attributes 
-                this dataloader requires to function
-        '''
-        logging.info("Initalising Sea Ice Thickness dataloader")
-        # Creates a class attribute for all keys in params
-        for key, val in params.items():
-            logging.debug(f"self.{key}={val} (dtype={type(val)}) from params")
-            setattr(self, key, val)
-        
-        # Import data
-        self.data = self.import_data(bounds)
-        
-        # Get data name from column name if not set in params
-        if self.data_name is None:
-            logging.debug('- Setting self.data_name from column name')
-            self.data_name = self.get_data_col_name()
-        # or if set in params, set col name to data name
-        else:
-            logging.debug(f'- Setting data column name to {self.data_name}')
-            self.data = self.set_data_col_name(self.data_name)
-                    
     def import_data(self, bounds):
         '''
         Creates a simulated dataset of sea ice thickness based on 
@@ -124,4 +93,6 @@ class ThicknessDataLoader(ScalarDataLoader):
         logging.debug("returning {} datapoints".format(len(thick_df.index)))
 
         del thick_df
+        # No need to trim data, as was defined by bounds
+
         return thickness_xr

--- a/polar_route/dataloaders/vector/abstractVector.py
+++ b/polar_route/dataloaders/vector/abstractVector.py
@@ -12,8 +12,7 @@ class VectorDataLoader(DataLoaderInterface):
     '''
     Abstract class for all vector Datasets.
     '''
-    @abstractmethod
-    def __init__(self, bounds, params, min_dp):
+    def __init__(self, bounds, params):
         '''
         This is where large-scale operations are performed, 
         such as importing data, downsampling, reprojecting, and renaming 

--- a/polar_route/dataloaders/vector/balticCurrent.py
+++ b/polar_route/dataloaders/vector/balticCurrent.py
@@ -5,35 +5,6 @@ import logging
 import xarray as xr
 
 class BalticCurrentDataLoader(VectorDataLoader):
-    def __init__(self, bounds, params):
-        '''
-        Initialises Baltic currents dataset. Does no post-processing
-        
-        Args:
-            bounds (Boundary): 
-                Initial boundary to limit the dataset to
-            params (dict):
-                Dictionary of {key: value} pairs. Keys are attributes 
-                this dataloader requires to function
-        '''
-        logging.info("Initalising Baltic currents dataloader")
-        # Creates a class attribute for all keys in params
-        for key, val in params.items():
-            logging.debug(f"self.{key}={val} (dtype={type(val)}) from params")
-            setattr(self, key, val)
-        
-        # Import data
-        self.data = self.import_data(bounds)
-        
-        # Get data name from column name if not set in params
-        if self.data_name is None:
-            logging.debug('- Setting self.data_name from column name')
-            self.data_name = self.get_data_col_name()
-        # or if set in params, set col name to data name
-        else:
-            logging.debug(f'- Setting data column name to {self.data_name}')
-            self.data = self.set_data_col_name(self.data_name)
-        
     def import_data(self, bounds):
         '''
         Reads in data from a BSOSE Depth NetCDF file. 
@@ -48,22 +19,15 @@ class BalticCurrentDataLoader(VectorDataLoader):
                 Baltic currents dataset within limits of bounds. 
                 Dataset has coordinates 'lat', 'long', and variable 'uC', 'vC'
         '''
-        logging.info(f"- Opening file {self.file}")
         # Open Dataset
-        data = xr.open_dataset(self.file)
+        data = xr.open_mfdataset(self.files)
         # Change column names
         data = data.rename({'latitude': 'lat',
                             'longitude': 'long',
                             'uo': 'uC',
                             'vo': 'vC'})
-
-        # Limit to initial boundary
-        logging.info('- Limiting to initial bounds')
-        data = data.sel(lat=slice(bounds.get_lat_min(),
-                                  bounds.get_lat_max()))
-        data = data.sel(long=slice(bounds.get_long_min(),
-                                   bounds.get_long_max()))
-        data = data.sel(time=slice(bounds.get_time_min(), 
-                                   bounds.get_time_max()))
+        
+        # Trim to initial datapoints
+        data = self.trim_datapoints(bounds, data=data)
         
         return data

--- a/polar_route/dataloaders/vector/era5Wind.py
+++ b/polar_route/dataloaders/vector/era5Wind.py
@@ -7,35 +7,6 @@ import xarray as xr
 from datetime import datetime
 
 class ERA5WindDataLoader(VectorDataLoader):
-    def __init__(self, bounds, params):
-        '''
-        Initialises Baltic currents dataset. Does no post-processing
-        
-        Args:
-            bounds (Boundary): 
-                Initial boundary to limit the dataset to
-            params (dict):
-                Dictionary of {key: value} pairs. Keys are attributes 
-                this dataloader requires to function
-        '''
-        logging.info("Initalising ERA5 Wind dataloader")
-        # Creates a class attribute for all keys in params
-        for key, val in params.items():
-            logging.debug(f"self.{key}={val} (dtype={type(val)}) from params")
-            setattr(self, key, val)
-        
-        # Import data
-        self.data = self.import_data(bounds)
-        
-        # Get data name from column name if not set in params
-        if self.data_name is None:
-            logging.debug('- Setting self.data_name from column name')
-            self.data_name = self.get_data_col_name()
-        # or if set in params, set col name to data name
-        else:
-            logging.debug(f'- Setting data column name to {self.data_name}')
-            self.data = self.set_data_col_name(self.data_name)
-        
     def import_data(self, bounds):
         '''
         Reads in data from a ERA5 NetCDF file. 
@@ -49,9 +20,8 @@ class ERA5WindDataLoader(VectorDataLoader):
                 ERA5 wind dataset within limits of bounds. 
                 Dataset has coordinates 'lat', 'long', and variable 'elevation'
         '''
-        logging.info(f"- Opening file {self.file}")
         # Open Dataset
-        data = xr.open_dataset(self.file)
+        data = xr.open_mfdataset(self.files)
         # Change column names
         data = data.rename({'latitude': 'lat',
                             'longitude': 'long'})
@@ -67,13 +37,7 @@ class ERA5WindDataLoader(VectorDataLoader):
         # Reverse order of lat as array goes from max to min
         data = data.reindex(lat=data.lat[::-1])
 
-        # Limit to initial boundary
-        logging.info('- Limiting to initial bounds')
-        data = data.sel(lat=slice(bounds.get_lat_min(),
-                                  bounds.get_lat_max()))
-        data = data.sel(long=slice(bounds.get_long_min(),
-                                   bounds.get_long_max()))
-        data = data.sel(time=slice(time_min, 
-                                   bounds.get_time_max()))
+        # Trim to initial datapoints
+        data = self.trim_datapoints(bounds, data=data)
         
         return data

--- a/polar_route/dataloaders/vector/northSeaCurrent.py
+++ b/polar_route/dataloaders/vector/northSeaCurrent.py
@@ -5,36 +5,6 @@ import logging
 import xarray as xr
 
 class NorthSeaCurrentDataLoader(VectorDataLoader):
-    def __init__(self, bounds, params):
-        '''
-        Initialises North Sea currents dataset. Does no post-processing
-        
-        Args:
-            bounds (Boundary): 
-                Initial boundary to limit the dataset to
-            params (dict):
-                Dictionary of {key: value} pairs. Keys are attributes 
-                this dataloader requires to function
-        '''
-        logging.info("Initalising North Sea currents dataloader")
-        # Creates a class attribute for all keys in params
-        for key, val in params.items():
-            logging.debug(f"self.{key}={val} (dtype={type(val)}) from params")
-            setattr(self, key, val)
-        
-        # Import data
-        self.data = self.import_data(bounds)
-        
-        # Get data name from column name if not set in params
-        if self.data_name is None:
-            logging.debug('- Setting self.data_name from column name')
-            self.data_name = self.get_data_col_name()
-        # or if set in params, set col name to data name
-        else:
-            logging.debug(f'- Setting data column name to {self.data_name}')
-            self.data = self.set_data_col_name(self.data_name)
-        
-        
     def import_data(self, bounds):
         '''
         Reads in data from a BSOSE Depth NetCDF file. 
@@ -49,9 +19,8 @@ class NorthSeaCurrentDataLoader(VectorDataLoader):
                 North Sea currents dataset within limits of bounds. 
                 Dataset has coordinates 'lat', 'long', and variable 'uC', 'vC'
         '''
-        logging.info(f"- Opening file {self.file}")
         # Open Dataset
-        data = xr.open_dataset(self.file)
+        data = xr.open_mfdataset(self.files)
         # Change column names
         data = data.rename({'lon': 'long',
                             'times': 'time',
@@ -60,13 +29,7 @@ class NorthSeaCurrentDataLoader(VectorDataLoader):
         # Limit to just these coords and variables
         data = data[['uC','vC']]
         
-        # Limit to initial boundary
-        logging.info('- Limiting to initial bounds')
-        data = data.sel(lat=slice(bounds.get_lat_min(),
-                                  bounds.get_lat_max()))
-        data = data.sel(long=slice(bounds.get_long_min(),
-                                   bounds.get_long_max()))
-        data = data.sel(time=slice(bounds.get_time_min(), 
-                                   bounds.get_time_max()))
+        # Trim to initial datapoints
+        data = self.trim_datapoints(bounds, data=data)
         
         return data

--- a/polar_route/dataloaders/vector/oras5Current.py
+++ b/polar_route/dataloaders/vector/oras5Current.py
@@ -7,40 +7,6 @@ import numpy as np
 
 #TODO Read in 2 files, combine to one object
 class ORAS5CurrentDataLoader(VectorDataLoader):
-    def __init__(self, bounds, params):
-        '''
-        Initialises ORAS5 currents dataset. Does no post-processing.
-        NOTE - This dataloader uses a NetCDF file that has been pre-processed
-        to include both zonal and meridional velocities! Additional work 
-        needed to make it work with data straight from the website
-        
-        Args:
-            bounds (Boundary): 
-                Initial boundary to limit the dataset to
-            params (dict):
-                Dictionary of {key: value} pairs. Keys are attributes 
-                this dataloader requires to function
-        '''
-        
-        logging.info("Initalising ORAS5 currents dataloader")
-        # Creates a class attribute for all keys in params
-        for key, val in params.items():
-            logging.debug(f"self.{key}={val} (dtype={type(val)}) from params")
-            setattr(self, key, val)
-        
-        # Import data
-        self.data = self.import_data(bounds)
-        
-        # Get data name from column name if not set in params
-        if self.data_name is None:
-            logging.debug('- Setting self.data_name from column name')
-            self.data_name = self.get_data_col_name()
-        # or if set in params, set col name to data name
-        else:
-            logging.debug(f'- Setting data column name to {self.data_name}')
-            self.data = self.set_data_col_name(self.data_name)
-            
-        
     def import_data(self, bounds):
         '''
         Reads in data from a ORAS5 Depth NetCDF files. 
@@ -55,9 +21,8 @@ class ORAS5CurrentDataLoader(VectorDataLoader):
                 ORAS5 currents dataset within limits of bounds. 
                 Dataset has coordinates 'lat', 'long', and variable 'uC', 'vC'
         '''
-        logging.info(f"- Opening file {self.file}")
         # Open Dataset
-        data = xr.open_dataset(self.file)
+        data = xr.open_mfdataset(self.files)
         
         # Change column names
         data = data.rename({'nav_lon': 'long',
@@ -68,12 +33,6 @@ class ORAS5CurrentDataLoader(VectorDataLoader):
         data = data[['lat','long','uC','vC']]
         
         # Limit to initial boundary
-        logging.info('- Limiting to initial bounds')
-        data = data.sel(lat=slice(bounds.get_lat_min(),
-                                  bounds.get_lat_max()))
-        data = data.sel(long=slice(bounds.get_long_min(),
-                                   bounds.get_long_max()))
-        data = data.sel(time=slice(bounds.get_time_max(), 
-                                   bounds.get_time_max()))
+        data = self.trim_datapoints(bounds, data=data)
         
         return data

--- a/polar_route/dataloaders/vector/sose.py
+++ b/polar_route/dataloaders/vector/sose.py
@@ -1,40 +1,8 @@
 from polar_route.dataloaders.vector.abstractVector import VectorDataLoader
 
-import logging
-
 import xarray as xr
 
 class SOSEDataLoader(VectorDataLoader):
-
-    def __init__(self, bounds, params):
-        '''
-        Initialises Baltic currents dataset. Does no post-processing
-        
-        Args:
-            bounds (Boundary): 
-                Initial boundary to limit the dataset to
-            params (dict):
-                Dictionary of {key: value} pairs. Keys are attributes 
-                this dataloader requires to function
-        '''
-        logging.info("Initalising SOSE currents dataloader")
-        # Creates a class attribute for all keys in params
-        for key, val in params.items():
-            logging.debug(f"self.{key}={val} (dtype={type(val)}) from params")
-            setattr(self, key, val)
-        
-        # Import data
-        self.data = self.import_data(bounds)
-        
-        # Get data name from column name if not set in params
-        if self.data_name is None:
-            logging.debug('- Setting self.data_name from column name')
-            self.data_name = self.get_data_col_name()
-        # or if set in params, set col name to data name
-        else:
-            logging.debug(f'- Setting data column name to {self.data_name}')
-            self.data = self.set_data_col_name(self.data_name)
-            
     def import_data(self, bounds):
         '''
         Reads in data from a SOSE Currents NetCDF file. 
@@ -51,18 +19,15 @@ class SOSEDataLoader(VectorDataLoader):
         '''
 
         # Open dataset and cast to pandas df
-        logging.info(f"- Opening file {self.file}")
-        data = xr.open_dataset(self.file)
-
+        data = xr.open_mfdataset(self.files)
+        # Cast to dataframe to modify lon coordinate
         df = data.to_dataframe().reset_index()
         
         # Change long coordinate to be in [-180,180) domain rather than [0,360)
         df['long'] = df['lon'].apply(lambda x: x-360 if x>180 else x)
         # Extract relevant columns
         df = df[['lat','long','uC','vC']]
-        logging.info('- Limiting to initial bounds')
-        # Limit to  values between lat/long boundaries
-        df = df[df['long'].between(bounds.get_long_min(), bounds.get_long_max())]
-        df = df[df['lat'].between(bounds.get_lat_min(), bounds.get_lat_max())]
+        # Trim to initial datapoints
+        df = self.trim_datapoints(bounds, data=df)
 
         return df

--- a/polar_route/dataloaders/vector/vectorCSV.py
+++ b/polar_route/dataloaders/vector/vectorCSV.py
@@ -2,38 +2,9 @@ from polar_route.dataloaders.vector.abstractVector import VectorDataLoader
 
 import logging
 
-import pandas as pd
+import dask as dd
 
 class VectorCSVDataLoader(VectorDataLoader):
-    def __init__(self, bounds, params):
-        '''
-        Initialises dataset from CSV file. Does no post-processing
-        
-       Args:
-            bounds (Boundary): 
-                Initial boundary to limit the dataset to
-            params (dict):
-                Dictionary of {key: value} pairs. Keys are attributes 
-                this dataloader requires to function
-        '''
-        logging.info("Initalising Vector CSV dataloader")
-        # Creates a class attribute for all keys in params
-        for key, val in params.items():
-            logging.debug(f"self.{key}={val} (dtype={type(val)}) from params")
-            setattr(self, key, val)
-        
-        # Import data
-        self.data = self.import_data(bounds)
-        
-        # Get data name from column name if not set in params
-        if self.data_name is None:
-            logging.debug('- Setting self.data_name from column name')
-            self.data_name = self.get_data_col_name()
-        # or if set in params, set col name to data name
-        else:
-            logging.debug(f'- Setting data column name to {self.data_name}')
-            self.data = self.set_data_col_name(self.data_name)
-        
     def import_data(self, bounds):
         '''
         Reads in data from a CSV file. 
@@ -47,18 +18,9 @@ class VectorCSVDataLoader(VectorDataLoader):
                 Dataset has coordinates 'lat', 'long', potentially 'time',
                 and variable defined by column heading in csv file
         '''
-        logging.debug(f"- Opening file {self.file}")
-        # Load in a csv file
-        data = pd.read_csv(self.file)
-
-        logging.info('- Limiting to initial bounds')
-        # Limit to within boundaries
-        data = data[data['long'].between(bounds.get_long_min(), 
-                                         bounds.get_long_max())]
-        data = data[data['lat'].between(bounds.get_lat_min(), 
-                                        bounds.get_lat_max())]
-        if 'time' in data.columns:
-            data = data[data['time'].between(bounds.get_time_min(), 
-                                            bounds.get_time_max())]
+        # Read in data
+        data = dd.read_csv(self.files)
+        # Trim to initial datapoints
+        data = self.trim_datapoints(bounds, data=data)
         
         return data

--- a/polar_route/dataloaders/vector/vectorGRF.py
+++ b/polar_route/dataloaders/vector/vectorGRF.py
@@ -6,35 +6,6 @@ import pandas as pd
 import numpy as np
 
 class VectorGRFDataLoader(VectorDataLoader):
-    def __init__(self, bounds, params):
-        '''
-        Generates a dataset using a gaussian random field
-        
-        Args:
-            bounds (Boundary): 
-                Initial boundary to limit the dataset to
-            params (dict):
-                Dictionary of {key: value} pairs. Keys are attributes 
-                this dataloader requires to function
-        '''
-        logging.info("Initalising Scalar CSV dataloader")
-        # Creates a class attribute for all keys in params
-        for key, val in params.items():
-            logging.debug(f"self.{key}={val} (dtype={type(val)}) from params")
-            setattr(self, key, val)
-        
-        # Import data
-        self.data = self.import_data(bounds)
-        
-        # Get data name from column name if not set in params
-        if self.data_name is None:
-            logging.debug('- Setting self.data_name from column name')
-            self.data_name = self.get_data_col_name()
-        # or if set in params, set col name to data name
-        else:
-            logging.debug(f'- Setting data column name to {self.data_name}')
-            self.data = self.set_data_col_name(self.data_name)
-        
     def import_data(self, bounds):
         '''
         Creates data in the form of a Gaussian Random Field

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+dask
 folium
 geopandas
 matplotlib

--- a/tests/regression_tests/example_meshes/Enviromental_Meshes/create_mesh.output2013_4_80.json
+++ b/tests/regression_tests/example_meshes/Enviromental_Meshes/create_mesh.output2013_4_80.json
@@ -34,7 +34,7 @@
                     }
                 },
                 {
-                    "loader": "AMSR_folder",
+                    "loader": "AMSR",
                     "params": {
                         "folder": "../../datastore/sic/amsr_south/",
                         "hemisphere": "south",

--- a/tests/regression_tests/example_meshes/Enviromental_Meshes/create_mesh.output2016_6_80.json
+++ b/tests/regression_tests/example_meshes/Enviromental_Meshes/create_mesh.output2016_6_80.json
@@ -34,7 +34,7 @@
                     }
                 },
                 {
-                    "loader": "AMSR_folder",
+                    "loader": "AMSR",
                     "params": {
                         "folder": "../../datastore/sic/amsr_south/",
                         "hemisphere": "south",

--- a/tests/regression_tests/example_meshes/Vessel_Performance_Meshes/add_vehicle.output2013_4_80.json
+++ b/tests/regression_tests/example_meshes/Vessel_Performance_Meshes/add_vehicle.output2013_4_80.json
@@ -34,7 +34,7 @@
           }
         },
         {
-          "loader": "AMSR_folder",
+          "loader": "AMSR",
           "params": {
             "folder": "../../datastore/sic/amsr_south/",
             "hemisphere": "south",

--- a/tests/regression_tests/example_meshes/Vessel_Performance_Meshes/add_vehicle.output2017_6_80.json
+++ b/tests/regression_tests/example_meshes/Vessel_Performance_Meshes/add_vehicle.output2017_6_80.json
@@ -34,7 +34,7 @@
           }
         },
         {
-          "loader": "AMSR_folder",
+          "loader": "AMSR",
           "params": {
             "folder": "../../datastore/sic/amsr_south/",
             "hemisphere": "south",


### PR DESCRIPTION
Updated the factory and dataloaders to be able to read in either a single file, a single folder, or a list of files from the config. It is up to the creator of any new dataloaders to implement the method of reading multiple files within import_data(). 

This has the added benefit of simplifying the dataloaders, as the init method can be abstracted for all dataloaders now; all dataloaders will go through the following initialisation process:

1. Read in config params
2. Add in default params per dataloader if required
3. Import data from files
4. Downsample if required
5. Reproject if required
6. Trim data to initial boundary
7. Set data variable name

'AMSR_folder' is now removed from the dataloaders,  replaced with the regular AMSR dataloader. This is the only change made to the regression tests. 
[Here](https://github.com/antarctica/PolarRoute/files/11149846/dl_folder_tests.txt) is the regression test output.