### PR TITLE
Downsampling factors as list vs tuple

### DIFF
--- a/polar_route/dataloaders/factory.py
+++ b/polar_route/dataloaders/factory.py
@@ -127,7 +127,7 @@ class DataLoaderFactory:
         params['dataloader_name'] = name
         
         if 'downsample_factors' not in params:
-            params['downsample_factors'] = (1,1)
+            params['downsample_factors'] = [1,1]
 
         if 'data_name' not in params:
             params['data_name'] = None

--- a/polar_route/dataloaders/scalar/abstract_scalar.py
+++ b/polar_route/dataloaders/scalar/abstract_scalar.py
@@ -514,7 +514,7 @@ class ScalarDataLoader(DataLoaderInterface):
             agg_type = self.aggregate_type
         
         # If no downsampling
-        if self.downsample_factors == (1,1):
+        if self.downsample_factors == (1,1) :
             logging.debug("- self.downsample() called but don't have to")
             return self.data
         else:

--- a/polar_route/dataloaders/scalar/abstract_scalar.py
+++ b/polar_route/dataloaders/scalar/abstract_scalar.py
@@ -514,7 +514,8 @@ class ScalarDataLoader(DataLoaderInterface):
             agg_type = self.aggregate_type
         
         # If no downsampling
-        if self.downsample_factors == (1,1) :
+        if self.downsample_factors == (1,1) or \
+           self.downsample_factors == [1,1]:
             logging.debug("- self.downsample() called but don't have to")
             return self.data
         else:

--- a/polar_route/dataloaders/vector/abstract_vector.py
+++ b/polar_route/dataloaders/vector/abstract_vector.py
@@ -528,7 +528,8 @@ class VectorDataLoader(DataLoaderInterface):
             agg_type = self.aggregate_type
             
         # If no downsampling
-        if self.downsample_factors == (1,1):
+        if self.downsample_factors == (1,1) or \
+           self.downsample_factors == [1,1]:
             logging.debug("- self.downsample() called but don't have to")
             return self.data
         else:


### PR DESCRIPTION
Fixed bug where downsampling was being performed when factors were (1,1), rather than being skipped over.

The dataloader factory set the default to be a tuple (1,1), and the abstract dataloaders made a check to see if downsample_factors was (1,1). This conflicted with downsample factors read in from JSON's, as tuple's are saved as lists in JSON format. This meant that the comparison being made was actually `if (1,1) == [1,1]`, which it doesn't, and hence the downsampling was being triggered.

To fix this, I amended the default value in the factory to be [1,1], and also changed the abstract dataloaders to be able to compare both tuples and lists. 

[Here](https://github.com/antarctica/PolarRoute/files/11203213/ds_fix_tests.txt) are the passed regression tests