### PR TITLE
Geo json output

### DIFF
--- a/polar_route/cli.py
+++ b/polar_route/cli.py
@@ -8,6 +8,7 @@ from polar_route.utils import setup_logging, timed_call
 from polar_route.mesh_generation.mesh_builder import MeshBuilder
 from polar_route.vessel_performance.vessel_performance_modeller import VesselPerformanceModeller
 from polar_route.route_planner import RoutePlanner
+from polar_route.mesh_generation.environment_mesh import EnvironmentMesh
 
 
 @setup_logging
@@ -15,7 +16,8 @@ def get_args(
         default_output: str,
         config_arg: bool = True,
         mesh_arg: bool = False,
-        waypoints_arg: bool = False):
+        waypoints_arg: bool = False,
+        format_arg: bool = False):
     """
     Adds required command line arguments to all CLI entry points.
 
@@ -63,6 +65,11 @@ def get_args(
                         default=False,
                         action = "store_true",
                         help="output only the calculated paths")
+        
+    if format_arg:
+        ap.add_argument("format",
+                        help = "Export format to transform a mesh into. Supported \
+                        formats are JSON, GEOJSON")
 
 
     return ap.parse_args()
@@ -139,3 +146,27 @@ def optimise_routes_cli():
         if args.dijkstra:
              json.dump(info_dijkstra, open('{}_dijkstra.json'.format('.'.join(args.output.split('.')[:-1])), 'w'))
         json.dump(info, open(args.output, "w"))
+
+@timed_call
+def export_mesh_cli():
+    """
+        CLI entry point for exporting a mesh to standard formats.
+    """
+    print("test tit")
+    args = get_args("export_mesh.output.json", 
+                    config_arg = False, mesh_arg = True, format_arg = True)
+    
+    print(f" Mesh arg = {args.mesh}, format arg = {args.format}")
+    
+    logging.info("{} {}".format(inspect.stack()[0][3][:-4], version))
+
+    
+
+    mesh = json.load(args.mesh)
+
+    env_mesh = EnvironmentMesh.load_from_json(mesh)
+
+    logging.info(f"exporting mesh to {args.output} in format {args.format}")
+    env_mesh.save(args.output, args.format)
+
+

--- a/polar_route/mesh_generation/environment_mesh.py
+++ b/polar_route/mesh_generation/environment_mesh.py
@@ -207,6 +207,18 @@ class EnvironmentMesh:
             raise ValueError(f'Invalid cellbox index')
 
     def save(self, path, format="JSON"):
+        """
+            Saves this object to a location in local storage. 
+
+            Args:
+                path (String): The file location the mesh will be saved to.
+                format (String) (optional): The format the mesh will be saved in.
+                    If not format is given, default is JSON.
+                    Supported formats are:
+                        JSON
+                        GEOJSON
+        """
+        
 
         logging.info(f"- saving the environment mesh to {path}")
         with open(path, 'w') as f:

--- a/polar_route/mesh_generation/environment_mesh.py
+++ b/polar_route/mesh_generation/environment_mesh.py
@@ -206,11 +206,19 @@ class EnvironmentMesh:
         else:
             raise ValueError(f'Invalid cellbox index')
 
-    def save(self, path):
+    def save(self, path, format="JSON"):
 
         logging.info(f"- saving the environment mesh to {path}")
         with open(path, 'w') as f:
-            json.dump(self.to_json(), f)
+            if format.upper() == "JSON":
+                logging.info(f"Saving mesh in {format} format")
+                json.dump(self.to_json(), f)
+            elif format.upper() == "GEOJSON":
+                logging.info(f"Saving mesh in {format} format")
+                json.dump(self.to_geojson(), f)
+            else:
+                logging.warning(f"Cannot save mesh in a {format} format")
+
             if isinstance(self.agg_cellboxes[0], JGridAggregatedCellBox):
                dump_path = path.replace (".json" , ".dump")
                with open(dump_path, 'w') as dump_f:

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ setup(
         'console_scripts': [
             "create_mesh=polar_route.cli:create_mesh_cli",
             "add_vehicle=polar_route.cli:add_vehicle_cli",
-            "optimise_routes=polar_route.cli:optimise_routes_cli"],
+            "optimise_routes=polar_route.cli:optimise_routes_cli",
+            "export_mesh=polar_route.cli:export_mesh_cli"],
     },
     keywords=[],
     packages=find_packages(),


### PR DESCRIPTION
Adding ability to export EnvironmentMesh objects in standard geo.json format. 

Added optional argument 'format' to EnvironmentMesh.save(...)

Added CLI entry point 'export_mesh' 

All regression tests pass:
[pytest_DUMP.txt](https://github.com/antarctica/PolarRoute/files/11210318/pytest_DUMP.txt)
