### PR TITLE
Formatting json output

### DIFF
--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 __description__ = "PolarRoute: Long-distance maritime polar route planning taking into account complex changing environmental conditions"
 __license__ = "MIT"
 __author__ = "Jonathan Smith, Samuel Hall, George Coombs, Harrison Abbot, Ayat Fekry, James Byrne, Michael Thorne, Maria Fox"

--- a/polar_route/cli.py
+++ b/polar_route/cli.py
@@ -92,7 +92,7 @@ def create_mesh_cli():
 
     logging.info("Saving mesh to {}".format(args.output))
     info = cg.to_json()
-    json.dump(info, open(args.output, "w"))
+    json.dump(info, open(args.output, "w"), indent=4)
 
 
 @timed_call
@@ -114,7 +114,7 @@ def add_vehicle_cli():
 
     logging.info("Saving mesh to {}".format(args.output))
     info = vp.to_json()
-    json.dump(info, open(args.output, "w"))
+    json.dump(info, open(args.output, "w"), indent=4)
 
 
 @timed_call
@@ -140,12 +140,12 @@ def optimise_routes_cli():
 
     if args.path_only:
         if args.dijkstra:
-             json.dump(info_dijkstra['paths'], open('{}_dijkstra.json'.format('.'.join(args.output.split('.')[:-1])), 'w'))
-        json.dump(info['paths'], open(args.output, 'w'))
+             json.dump(info_dijkstra['paths'], open('{}_dijkstra.json'.format('.'.join(args.output.split('.')[:-1])), 'w'), indent=4)
+        json.dump(info['paths'], open(args.output, 'w'), indent=4)
     else:
         if args.dijkstra:
-             json.dump(info_dijkstra, open('{}_dijkstra.json'.format('.'.join(args.output.split('.')[:-1])), 'w'))
-        json.dump(info, open(args.output, "w"))
+             json.dump(info_dijkstra, open('{}_dijkstra.json'.format('.'.join(args.output.split('.')[:-1])), 'w'), indent=4)
+        json.dump(info, open(args.output, "w"), indent=4)
 
 @timed_call
 def export_mesh_cli():

--- a/polar_route/mesh_generation/environment_mesh.py
+++ b/polar_route/mesh_generation/environment_mesh.py
@@ -132,7 +132,7 @@ class EnvironmentMesh:
         output["cellboxes"] = self.cellboxes_to_json()
         output['neighbour_graph'] = self.neighbour_graph.get_graph()
 
-        return json.loads(json.dumps(output))
+        return json.loads(json.dumps(output, indent=4))
     
     def to_geojson(self):
         """
@@ -224,10 +224,10 @@ class EnvironmentMesh:
         with open(path, 'w') as f:
             if format.upper() == "JSON":
                 logging.info(f"Saving mesh in {format} format")
-                json.dump(self.to_json(), f)
+                json.dump(self.to_json(), f, indent=4)
             elif format.upper() == "GEOJSON":
                 logging.info(f"Saving mesh in {format} format")
-                json.dump(self.to_geojson(), f)
+                json.dump(self.to_geojson(), f, indent=4)
             else:
                 logging.warning(f"Cannot save mesh in a {format} format")
 

--- a/polar_route/route_planner.py
+++ b/polar_route/route_planner.py
@@ -296,7 +296,7 @@ class RoutePlanner:
         mesh = copy.copy(self.mesh)
         mesh['waypoints'] = mesh['waypoints'].to_dict()
         mesh['config']['route_info'] = self.config
-        output_json = json.loads(json.dumps(mesh))
+        output_json = json.loads(json.dumps(mesh), indent=4)
         del mesh
         return output_json
 


### PR DESCRIPTION
Date: 2023-05-22
Version Number: 0.2.4  
 
## Description of change
Added `indent=4` to `json.dump()` to format the json outputs to be more easily readable by default.

# Testing
Doesn't change any thing except json output files, so nothing would test it. Regardless, [here's](https://github.com/antarctica/PolarRoute/files/11531391/pytest_vessel.txt) the vessel tests passing to prove that nothing broke (vessel because it was the fastest).


- [x] My changes result in all required regression tests passing without the need to update test files.  

> *include pytest.txt file showing all tests passing.*  

- [ ] My changes require one or more test files to be updated for all regression tests to pass.   

> *include pytest.txt file showing which tests fail.*  
> *include reasoning as to why your changes cause these tests to fail.* 
>
> Should these changes be valid, relevant test files should be updated.  
> *include pytest.txt file of test passing after test files have been updated.*

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `0.2.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   