### PR TITLE
Fix typo and update CLI output order

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,7 +34,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.coverage',
     'sphinx.ext.napoleon',
-    'rinoh.frontend.sphinx',
+    # 'rinoh.frontend.sphinx',
     'sphinx.ext.todo',
     'sphinx.ext.autosectionlabel',
     'sphinx_rtd_theme',

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,5 @@
 Welcome to the PolarRoute Manual Pages
-=====================================
+======================================
 
 PolarRoute is a tool for the optimisation of routes for maritime vehicles travelling in polar waters.
 This software package has been developed by the **British Antarctic Survey** (BAS), primarily 

--- a/docs/source/sections/Configuration.rst
+++ b/docs/source/sections/Configuration.rst
@@ -11,7 +11,8 @@ Outlined below is an example configuration file for running PolarRoute. Using th
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Mesh Construction configuration file example.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-::
+.. code-block:: json
+    
     {
         "config": {
             "Mesh_info": {

--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 __description__ = "PolarRoute: Long-distance maritime polar route planning taking into account complex changing environmental conditions"
 __license__ = "MIT"
 __author__ = "Jonathan Smith, Samuel Hall, George Coombs, Harrison Abbot, Ayat Fekry, James Byrne, Michael Thorne, Maria Fox"

--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 __description__ = "PolarRoute: Long-distance maritime polar route planning taking into account complex changing environmental conditions"
 __license__ = "MIT"
 __author__ = "Jonathan Smith, Samuel Hall, George Coombs, Harrison Abbot, Ayat Fekry, James Byrne, Michael Thorne, Maria Fox"

--- a/polar_route/cli.py
+++ b/polar_route/cli.py
@@ -133,18 +133,22 @@ def optimise_routes_cli():
         logging.info("outputting full mesh to {}".format(args.output))
 
     rp = RoutePlanner(args.mesh.name, args.config.name, args.waypoints.name)
+    
     rp.compute_routes()
     info_dijkstra = rp.to_json()
+    
+    if args.dijkstra:
+        if args.path_only:
+            json.dump(info_dijkstra['paths'], open('{}_dijkstra.json'.format('.'.join(args.output.split('.')[:-1])), 'w'), indent=4)
+        else:
+            json.dump(info_dijkstra, open('{}_dijkstra.json'.format('.'.join(args.output.split('.')[:-1])), 'w'), indent=4)
+    
     rp.compute_smoothed_routes()
     info = rp.to_json()
 
     if args.path_only:
-        if args.dijkstra:
-             json.dump(info_dijkstra['paths'], open('{}_dijkstra.json'.format('.'.join(args.output.split('.')[:-1])), 'w'), indent=4)
         json.dump(info['paths'], open(args.output, 'w'), indent=4)
     else:
-        if args.dijkstra:
-             json.dump(info_dijkstra, open('{}_dijkstra.json'.format('.'.join(args.output.split('.')[:-1])), 'w'), indent=4)
         json.dump(info, open(args.output, "w"), indent=4)
 
 @timed_call

--- a/polar_route/dataloaders/scalar/scalar_csv.py
+++ b/polar_route/dataloaders/scalar/scalar_csv.py
@@ -1,6 +1,6 @@
 from polar_route.dataloaders.scalar.abstract_scalar import ScalarDataLoader
 
-import dask as dd
+import pandas as pd
 
 class ScalarCSVDataLoader(ScalarDataLoader):
     def import_data(self, bounds):
@@ -17,7 +17,11 @@ class ScalarCSVDataLoader(ScalarDataLoader):
                 and variable defined by column heading in csv file
         '''
         # Read in data
-        data = dd.read_csv(self.files)
+        df_list = []
+        # NOTE: All csv files must have same columns for this to work
+        for file in self.files:
+            df_list += [pd.read_csv(file)]
+        data = pd.concat(df_list)
         # Trim to initial datapoints
         data = self.trim_datapoints(bounds, data=data)
         

--- a/polar_route/dataloaders/vector/vector_csv.py
+++ b/polar_route/dataloaders/vector/vector_csv.py
@@ -1,8 +1,6 @@
 from polar_route.dataloaders.vector.abstract_vector import VectorDataLoader
 
-import logging
-
-import dask as dd
+import pandas as pd
 
 class VectorCSVDataLoader(VectorDataLoader):
     def import_data(self, bounds):
@@ -19,7 +17,11 @@ class VectorCSVDataLoader(VectorDataLoader):
                 and variable defined by column heading in csv file
         '''
         # Read in data
-        data = dd.read_csv(self.files)
+        df_list = []
+        # NOTE: All csv files must have same columns for this to work
+        for file in self.files:
+            df_list += [pd.read_csv(file)]
+        data = pd.concat(df_list)
         # Trim to initial datapoints
         data = self.trim_datapoints(bounds, data=data)
         

--- a/polar_route/mesh_generation/environment_mesh.py
+++ b/polar_route/mesh_generation/environment_mesh.py
@@ -214,9 +214,9 @@ class EnvironmentMesh:
                 path (String): The file location the mesh will be saved to.
                 format (String) (optional): The format the mesh will be saved in.
                     If not format is given, default is JSON.
-                    Supported formats are:
-                        JSON
-                        GEOJSON
+                    Supported formats are\n
+                        - JSON \n
+                        - GEOJSON
         """
         
 

--- a/polar_route/route_planner.py
+++ b/polar_route/route_planner.py
@@ -296,7 +296,7 @@ class RoutePlanner:
         mesh = copy.copy(self.mesh)
         mesh['waypoints'] = mesh['waypoints'].to_dict()
         mesh['config']['route_info'] = self.config
-        output_json = json.loads(json.dumps(mesh), indent=4)
+        output_json = json.loads(json.dumps(mesh, indent=4))
         del mesh
         return output_json
 

--- a/polar_route/vessel_performance/vessels/SDA.py
+++ b/polar_route/vessel_performance/vessels/SDA.py
@@ -147,10 +147,10 @@ class SDA(AbstractShip):
     def invert_resistance(self, cellbox):
         """
             Method to find the vessel speed that keeps the ice resistance force below a given threshold in a given cell.
-            The input cellbox should contain the following values:
-                sic (float): The average sea ice concentration in the cell as a percentage
-                thickness (float): The average ice thickness in the cell in m
-                density (float): The average ice density in the cell in kg/m^3
+            The input cellbox should contain the following values\n
+                sic (float) - The average sea ice concentration in the cell as a percentage \n
+                thickness (float) - The average ice thickness in the cell in m \n
+                density (float) - The average ice density in the cell in kg/m^3 \n
 
             Args:
                 cellbox (AggregatedCellBox): input cell from environmental mesh


### PR DESCRIPTION
Date: 2023-05-23
Version Number: 0.2.6
 
## Description of change
Fixed a bug introduced in  #187 which prevented the cli from running `optimise_routes`. 

Also adjusted the cli to output the dijkstra path (if the -d flag is provided) **_before_** attempting to smooth the path. This enables us to get a path out even if the smoothing crashes. 

# Testing
I should have caught the typo before pushing #187, so for now completeness, here's the [dijkstra](https://github.com/antarctica/PolarRoute/files/11542303/pytest_dijkstra.txt) and [smoothed](https://github.com/antarctica/PolarRoute/files/11542410/pytest_smoothed.txt) regression tests passing





- [x] My changes result in all required regression tests passing without the need to update test files.  

> *include pytest.txt file showing all tests passing.*  

- [ ] My changes require one or more test files to be updated for all regression tests to pass.   

> *include pytest.txt file showing which tests fail.*  
> *include reasoning as to why your changes cause these tests to fail.* 
>
> Should these changes be valid, relevant test files should be updated.  
> *include pytest.txt file of test passing after test files have been updated.*

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `0.2.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   