### PR TITLE
updated export_mesh CLI doc and added default path for tif in CLI if …

### DIFF
--- a/docs/source/sections/running.rst
+++ b/docs/source/sections/running.rst
@@ -156,6 +156,14 @@ supported output formats are:
   * geo.json (collection of polygons for each cell in the mesh) [GEOJSON]
   * .tif (rasterised mesh) [TIF]
 
+optional arguments:
+
+::
+
+    -v : verbose logging
+    -o : output location
+    -format_conf: configuration file for output format (required for TIF export)
+
 
 ^^^^^^^^^^^^^^^^^^
 Plotting

--- a/polar_route/cli.py
+++ b/polar_route/cli.py
@@ -157,8 +157,11 @@ def export_mesh_cli():
     """
         CLI entry point for exporting a mesh to standard formats.
     """
+
     args = get_args("export_mesh.output.json", 
                     config_arg = False, mesh_arg = True, format_arg = True)
+    if args.format.upper() == "TIF" and  args.output == "export_mesh.output.json": # check if the output file name is not provided set to a defualt name
+        args.output = "mesh.tif"
     
     print(f" Mesh arg = {args.mesh}, format arg = {args.format}")
     


### PR DESCRIPTION
I did minor tweaks to update export_mesh CLI doc and add default path for tif in CLI if not provided.

[test_output.txt](https://github.com/antarctica/PolarRoute/files/11562978/test_output.txt)
