### PR TITLE
Implemented add_dataloader() 

### DIFF
--- a/docs/source/sections/Dataloaders/AddingDataloaders.rst
+++ b/docs/source/sections/Dataloaders/AddingDataloaders.rst
@@ -1,0 +1,97 @@
+.. _adding-dataloaders:
+
+Adding New Dataloaders
+============================
+
+Adding to the repository
+------------------------
+
+Each dataloader is to be implemented as a separate object for the Environmental mesh to interface with. 
+The general workflow for creating a new dataloader is as follows:
+
+#. Choose an approriate dataloader type (see :ref:`Dataloader Types`).
+#. Create a new file under :code:`polar_route/DataLoaders/{dataloader-type}` with an appropriate name.
+#. Create :code:`import_data()` and (optianally) :code:`add_default_params()` methods. Examples of how to do this are shown on the :ref:`abstractScalar<abstract-scalar-dataloader-index>` and :ref:`abstractVector<abstract-vector-dataloader-index>` pages.
+#. Add a new entry to the dataloader factory object, within :code:`polar_route/Dataloaders/Factory.py`. Instructions on how to do so are shown in :ref:`dataloader-factory`
+
+After performing these actions, the dataloader should be ready to go. It is useful for debugging purposes 
+to create the dataloader object from within :code:`polar_route/Dataloaders/Factory.py` (e.g. within
+:code:`if __name__=='__main__':` ) and test its functionality before deploying it.
+
+
+
+Adding within iPython Notebooks
+-------------------------------
+
+If you do not wish to modify the repo to add a dataloader, you may add one into the mesh by calling the 
+:code:`add_dataloader()` method of :ref:`MeshBuilder`.
+
+An example of how to do this is detailed below. Assuming you're working out of a Jupyter notebook, the 
+basic steps would be to
+
+#. Create a dataloader
+   ::
+      
+      # Import the abstract dataloader as the base class
+      from polar_route.dataloaders.scalar.abstract_scalar import ScalarDataLoader
+      
+      # Set up dataloader in the same way as the existing dataloaders
+      class MyDataLoader(ScalarDataLoader):
+         # Only user defined function required
+         def import_data(self, bounds):
+            # Read in data
+            if len(self.files) == 1:    data = xr.open_dataset(self.files[0])
+            else:                       data = xr.open_mfdataset(self.files)
+            # Trim data to boundary
+            data = self.trim_datapoints(bounds, data=data)
+
+            return data
+   
+#. Create a dictionary of parameters to initialise the dataloader
+   ::
+      
+      # Params formatted same way as dataloaders in config
+      params = {
+         'files': [  
+            'PATH_TO_FILE_1',
+            'PATH_TO_FILE_2',
+            ... # Populate with as many files as you need
+         ],
+         'data_name': 'my_data',
+         'splitting_conditions':[
+            {
+            'my_data':{
+               'threshold': 0.5,
+               'upper_bound': 0.9,
+               'lower_bound': 0.1
+               }
+            }
+         ]
+      }
+
+#. Initialise an Environmental Mesh
+   ::
+
+      import json
+      from polar_route import MeshBuilder
+
+      # Config to initialise mesh from
+      with open('config.json', 'r') as fp:
+         config = json.load(fp)
+
+      # Build a mesh from the config
+      mesh_builder = MeshBuilder(config)
+      env_mesh = mesh_builder.build_environmental_mesh()
+
+#. Add dataloader to mesh
+   ::
+
+      # Set up bounds of data in dataloader
+      from polar_route import Boundary
+      bounds = Boundary.from_json(config)
+
+      # Add dataloader to mesh builder and regenerate mesh
+      modified_builder = mesh_builder.add_dataloader(MyDataLoader, params, bounds)
+      modified_mesh = modified_builder.build_environmental_mesh()
+
+

--- a/docs/source/sections/Dataloaders/Factory.rst
+++ b/docs/source/sections/Dataloaders/Factory.rst
@@ -22,14 +22,16 @@ a parameter the dataloader requires. The actions are:
 
 #. Import the dataloader
 #. Add an entry to the :code:`dataloader_requirements` dictionary
-#. (OPTIONAL) Add a default value to :code:`set_default_params()`
 
 ^^^^^^^
 Example
 ^^^^^^^
 In this example, a new scalar dataloader `myScalarDataloader` has been created, and
 is located at :code:`polar_route/Dataloaders/Scalar/myScalarDataloader.py`.
-The only parameter required by this dataloader is a file to read data from::
+
+The only parameter required by this dataloader is a file to read data from. 'files' 
+is passed as a mandatory parameter, as 'file' and 'folder' both get translated into 
+a list of files, and stored in params under the key 'files'::
 
    # Add new import statement for Factory to read
    from polar_route.Dataloaders.Scalar.myScalarDataloader import myScalarDataloader
@@ -42,20 +44,27 @@ The only parameter required by this dataloader is a file to read data from::
          ...
          dataloader_requirements = {
             ...
-            # Add new dataloader
-            'myscalar':    (myScalarDataloader, ['file'])
+            # Add new dataloaders
+            'myscalar':    (myScalarDataloader, ['files'])
             ...
          ...
       ...
 
 
 To call this dataloader, add an entry in the :code:`config.json` 
-file used to generate the mesh::
+file used to generate the mesh. Alternatively, add a folder, or a list of 
+individual files::
    
    {
          "loader": "myscalar",
          "params": {
-            "file": "PATH_TO_DATA_FILE",
+            "file": "PATH_TO_DATA_FILE"   # For a single file
+            "folder": "PATH_TO_FOLDER"    # For a folder, must have trailing '/'
+            "files":[                     # For a list of individual files
+               "PATH_TO_FILE_1",
+               "PATH_TO_FILE_2",
+               ...
+            ]
          }
    }
 

--- a/docs/source/sections/Dataloaders/overview.rst
+++ b/docs/source/sections/Dataloaders/overview.rst
@@ -12,9 +12,9 @@ Dataloader Overview
    ./Factory
    ./scalar/index
    ./vector/index
+   ./AddingDataloaders
    
 
-################
 Section Overview
 ################
 
@@ -35,26 +35,8 @@ however this can be whatever the user needs, so long as they are cast into eithe
    *UML Diagram detailing the dataloader subsystem*
 
 
-
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Implementing New Dataloaders
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Each dataloader is to be implemented as a separate object for the Environmental mesh to interface with. 
-The general workflow for creating a new dataloader is as follows:
-
-#. Choose an approriate dataloader type (see `Dataloader Types`_).
-#. Create a new file under :code:`polar_route/DataLoaders/{dataloader-type}` with an appropriate name.
-#. Create :code:`__init__()` and :code:`import_data()` methods. Examples of how to do this are shown on the :ref:`abstractScalar<abstract-scalar-dataloader-index>` and :ref:`abstractVector<abstract-vector-dataloader-index>` pages.
-#. Add a new entry to the dataloader factory object, within :code:`polar_route/Dataloaders/Factory.py`. Instructions on how to do so are shown in :ref:`dataloader-factory`
-
-After performing these actions, the dataloader should be ready to go. It is useful for debugging purposes 
-to create the dataloader object from within :code:`polar_route/Dataloaders/Factory.py` (e.g. within
-:code:`if __name__=='__main__':` ) and test its functionality before deploying it.
-
-^^^^^^^^^^^^^^^^
 Dataloader Types
-^^^^^^^^^^^^^^^^
+================
 
 There are two main types of dataloaders that are implemented as abstract classes: Scalar and Vector.
 
@@ -63,7 +45,7 @@ There are two main types of dataloaders that are implemented as abstract classes
 per latitude/longitude(/time) coordinate. Examples of this are bathymetry, sea ice concentration, etc... 
 While the raw datasets may contain more than one variable (a common example being the existance of values and errors in the same file), 
 these *MUST* be cut down to just coordinates, and a single variable, in order to work correctly with the :ref:`abstractScalar<abstract-scalar-dataloader>` dataloader.
-To read more on how to implement these, follow instructions in `Implementing New Dataloaders`_ and the :ref:`abstract scalar dataloader page<abstract-scalar-dataloader-index>`.
+To read more on how to implement these, follow instructions in :ref:`Adding Dataloaders page<adding-dataloaders>` and the :ref:`abstract scalar dataloader page<abstract-scalar-dataloader-index>`.
 
 **Vector dataloaders** are to be used on vector datasets; i.e. variables with multi-dimensional values
 per latitude/longitude(/time) coordinate. Examples of this are ocean currents,
@@ -71,7 +53,7 @@ wind, etc... The datasets will have multiple data variables, and should be cut d
 and optionally 'time'), and the values for each dimensional component of the variable. This will generally be two dimensions, 
 however the :ref:`abstractVector<abstract-vector-dataloader>` dataloader should be flexible to n-dimensional data. 
 Rigor should be taken when testing these dataloaders to ensure that the outputs of :code:`get_value()` method of these dataloaders produces outputs that make sense.
-To read more on how to implement these, follow instructions in `Implementing New Dataloaders`_ and :ref:`abstract vector dataloader page<abstract-vector-dataloader-index>`.
+To read more on how to implement these, follow instructions in :ref:`Adding Dataloaders page<adding-dataloaders>` and :ref:`abstract vector dataloader page<abstract-vector-dataloader-index>`.
 
 .. **Look-up Table Dataloaders** are to be used on datasets where boundaries define a value.
 .. Real data is always prefered to this method, however in the case where there is no data, the LUT
@@ -81,9 +63,9 @@ To read more on how to implement these, follow instructions in `Implementing New
 
 
 
-^^^^^^^^^^^^^^^^^^^^
+
 Abstract Dataloaders
-^^^^^^^^^^^^^^^^^^^^
+====================
 To look at specific abstract dataloaders, use the following links:
 
 - :ref:`abstract-scalar-dataloader`
@@ -101,7 +83,7 @@ reduce memory consumption.
 Both abstract base classes define the :code:`__init__()` function to have the following process:
 
 #. Read in params from config
-#. Add params from :code:`self.add_params()`, defined by user when creating a dataloader
+#. Add params from :code:`self.add_default_params()`, defined by user when creating a dataloader
 #. Downsample data if required and if loaded as :code:`xarray.Dataset`
 #. Reproject data if required
 #. Trim datapoints to initial boundary

--- a/docs/source/sections/Dataloaders/scalar/index.rst
+++ b/docs/source/sections/Dataloaders/scalar/index.rst
@@ -50,12 +50,14 @@ Below is a simple example of how to load in a NetCDF file::
 
 
 Sometimes there are parameters that are constant for a data source, but are not 
-constant for all data sources. Default values may be defined either in the
-dataloader factory, or within the dataloader itself. Below is an example of 
-setting default parameters for reprojection of a dataset::
+constant for all data sources. Default values are defined in the dataloader :code:`add_default_params()`.
+Below is an example of setting default parameters for reprojection of a dataset::
 
     class MyDataLoader(ScalarDataLoader):
-        def add_params(self, params):
+        def add_default_params(self, params):
+            # Add all the regular default params that scalar dataloaders have
+            params = super().add_default_params(params) # This line MUST be included
+
             # Define projection of dataset being imported
             params['in_proj'] = 'EPSG:3412'
             # Define projection required by output 
@@ -65,6 +67,8 @@ setting default parameters for reprojection of a dataset::
             # Coordinates in dataset that will be reprojected into long/lat
             params['x_col'] = 'x' # Becomes 'long'
             params['y_col'] = 'y' # Becomes 'lat'
+
+            return params
             
         def import_data(self, bounds):
             # Open Dataset

--- a/docs/source/sections/Dataloaders/vector/index.rst
+++ b/docs/source/sections/Dataloaders/vector/index.rst
@@ -61,7 +61,10 @@ be defined either in the dataloader factory, or within the dataloader itself.
 Below is an example of setting default parameters for reprojection of a dataset::
 
     class MyDataLoader(ScalarDataLoader):
-        def add_params(self, params):
+        def add_default_params(self, params):
+            # Add all the regular default params that scalar dataloaders have
+            params = super().add_default_params(params) # This line MUST be included
+
             # Define projection of dataset being imported
             params['in_proj'] = 'EPSG:3412'
             # Define projection required by output 

--- a/docs/source/sections/Discrete_meshing.rst
+++ b/docs/source/sections/Discrete_meshing.rst
@@ -1,3 +1,5 @@
+.. _mesh-construction:
+
 ********************************
 Methods - Mesh Construction
 ********************************
@@ -65,13 +67,13 @@ MetaData
   
 
 MeshBuilder
-************
+***********
 
 .. automodule:: polar_route.mesh_generation.mesh_builder
 
 .. autoclass:: polar_route.mesh_generation.mesh_builder.MeshBuilder
    :special-members: __init__  
-   :members: build_environmental_mesh , split_and_replace, split_to_depth
+   :members: build_environmental_mesh , split_and_replace, split_to_depth, add_dataloader
 
 AggregatedCellBox
 ******************

--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 __description__ = "PolarRoute: Long-distance maritime polar route planning taking into account complex changing environmental conditions"
 __license__ = "MIT"
 __author__ = "Jonathan Smith, Samuel Hall, George Coombs, Harrison Abbot, Ayat Fekry, James Byrne, Michael Thorne, Maria Fox"

--- a/polar_route/dataloaders/factory.py
+++ b/polar_route/dataloaders/factory.py
@@ -58,6 +58,10 @@ class DataLoaderFactory:
         # Translate 'file' or 'folder' into 'files' key
         params = self.translate_file_input(params)
         
+        # Add loader name to params
+        params['dataloader_name'] = name
+        params['min_dp'] = min_dp
+        
         dataloader_requirements = {
             # Scalar
             'scalar_csv':   (ScalarCSVDataLoader, ['files']),
@@ -73,10 +77,10 @@ class DataLoaderFactory:
             'thickness':    (ThicknessDataLoader, []),
             'density':      (DensityDataLoader, []),
             # Scalar - Abstract shapes
-            'circle':       (ShapeDataLoader, ['shape']),
-            'square':       (ShapeDataLoader, ['shape']),
-            'gradient':     (ShapeDataLoader, ['shape']),
-            'checkerboard': (ShapeDataLoader, ['shape']),
+            'circle':       (ShapeDataLoader, []),
+            'square':       (ShapeDataLoader, []),
+            'gradient':     (ShapeDataLoader, []),
+            'checkerboard': (ShapeDataLoader, []),
             # Vector
             'vector_csv':       (VectorCSVDataLoader, ['files']),
             'vector_grf':       (VectorGRFDataLoader, []),

--- a/polar_route/dataloaders/factory.py
+++ b/polar_route/dataloaders/factory.py
@@ -55,14 +55,14 @@ class DataLoaderFactory:
         '''
         # Cast name to lowercase to make case insensitive
         name = name.lower()
-        # Add default values if they don't exist
-        params = self.set_default_params(name, params, min_dp)
+        # Translate 'file' or 'folder' into 'files' key
+        params = self.translate_file_input(params)
         
         dataloader_requirements = {
             # Scalar
             'scalar_csv':   (ScalarCSVDataLoader, ['files']),
-            'scalar_grf':   (ScalarGRFDataLoader, []),
-            'binary_grf':   (ScalarGRFDataLoader,[]),
+            'scalar_grf':   (ScalarGRFDataLoader, ['binary']),
+            'binary_grf':   (ScalarGRFDataLoader,['binary']),
             'amsr':         (AMSRDataLoader, ['files', 'hemisphere']),
             'bsose_sic':    (BSOSESeaIceDataLoader, ['files']),
             'bsose_depth':  (BSOSEDepthDataLoader, ['files']),
@@ -73,10 +73,10 @@ class DataLoaderFactory:
             'thickness':    (ThicknessDataLoader, []),
             'density':      (DensityDataLoader, []),
             # Scalar - Abstract shapes
-            'circle':       (ShapeDataLoader, ['shape', 'nx', 'ny', 'radius', 'centre']),
-            'square':       (ShapeDataLoader, ['shape', 'nx', 'ny', 'side_length', 'centre']),
-            'gradient':     (ShapeDataLoader, ['shape', 'nx', 'ny', 'vertical']),
-            'checkerboard': (ShapeDataLoader, ['shape', 'nx', 'ny', 'gridsize']),
+            'circle':       (ShapeDataLoader, ['shape']),
+            'square':       (ShapeDataLoader, ['shape']),
+            'gradient':     (ShapeDataLoader, ['shape']),
+            'checkerboard': (ShapeDataLoader, ['shape']),
             # Vector
             'vector_csv':       (VectorCSVDataLoader, ['files']),
             'vector_grf':       (VectorGRFDataLoader, []),
@@ -103,166 +103,19 @@ class DataLoaderFactory:
         # Create instance of dataloader
         return data_loader(bounds, params)
     
-    def set_default_params(self, name, params, min_dp):
+    def translate_file_input(self, params):
         '''
-        Set default values for all dataloaders. 
+        Allows flexible file specification in params. Translates 'file' or 
+        'folder' into 'files'
         
         Args:
-            name (str):
-                Name of dataloader entry in dataloader_requirements. Used to
-                specify default parameters for a specific dataloader.
             params (dict): 
-                Dictionary containing attributes that are required for each 
-                dataloader. 
-            min_dp (int):
-                Minimum number of datapoints required to return a homogeneity 
-                condition. Passed in here so it can be added to params
-            
-        Returns:
-            (dict): 
-                Dictionary of attributes the dataloader will require, 
-                completed with default values if not provided in config.
+                Dictionary of parameters written in config
         '''
-        # Save dataloader name in params
-        params['dataloader_name'] = name
-        
-        if 'downsample_factors' not in params:
-            params['downsample_factors'] = [1,1]
-
-        if 'data_name' not in params:
-            params['data_name'] = None
-
-        if 'aggregate_type' not in params: 
-            params['aggregate_type']  = 'MEAN'
-            
-        if 'min_dp' not in params:
-            params['min_dp'] = min_dp
-            
-        if 'in_proj' not in params:
-            params['in_proj'] = 'EPSG:4326'
-            
-        if 'out_proj' not in params:
-            params['out_proj'] = 'EPSG:4326'
-            
-        if 'x_col' not in params:
-            params['x_col'] = 'lat'
-
-        if 'y_col' not in params:
-            params['y_col'] = 'long'
-            
         if 'file' in params:
             params['files'] = [params['file']]
         elif 'folder' in params:
             folder = os.path.join(params['folder'], '') # Adds trailing slash if non-existant
             params['files'] = sorted(glob(folder+'*'))
-            
-        # Set defaults for abstract data generators
-        if name in ['circle', 'checkerboard', 'gradient']:
-            params = self.set_default_shape_params(name, params)
         
-        # Set defaults for GRF generators
-        if name in ['binary_grf', 'scalar_grf', 'vector_grf']:
-            params = self.set_default_grf_params(name, params)
-        
-        return params
-    
-    def set_default_shape_params(self, name, params):
-        '''
-        Set default values for abstract shape dataloaders. This function is
-        seperated out from set_default_params() simply to reduce cognitive
-        complexity, but is otherwise in the same format.
-        
-        Args:
-            name (str):
-                Name of shape entry in dataloader_requirements. Used to
-                specify default parameters for the shape dataloader.
-            params (dict): 
-                Dictionary containing attributes that are required for the
-                shape being loaded.
-            
-        Returns:
-            (dict): 
-                Dictionary of attributes the dataloader will require, 
-                completed with default values if not provided in config.
-        '''
-        # Number of datapoints to populate per axis
-        if 'nx' not in params:
-            params['nx'] = 101
-        if 'ny' not in params:
-            params['ny'] = 101
-            
-        # Shape of abstract dataset
-        if 'shape' not in params:
-            params['shape'] = name
-            
-        # Define default circle parameters
-        if name == 'circle':
-            if 'radius' not in params:
-                params['radius'] = 1
-            if 'centre' not in params:
-                params['centre'] = (None, None)
-        # Define default square parameters
-        elif name == 'square':
-            if 'side_length' not in params:
-                params['side_length'] = 1
-            if 'centre' not in params:
-                params['centre'] = (None, None)
-        # Define default gradient params
-        elif name == 'gradient':
-            if 'vertical' not in params:
-                params['vertical'] = True
-        # Define default checkerboard params
-        elif name == 'checkerboard':
-            if 'gridsize' not in params:
-                params['gridsize'] = (1,1)   
-        
-        
-        return params
-
-    def set_default_grf_params(self, name, params):
-        # Params that all GRF dataloaders need
-        if 'data_name' not in params:
-            params['data_name'] = 'data'
-        if 'seed' not in params:
-            params['seed'] = None
-        if 'size' not in params:
-            params['size'] = 512
-        if 'alpha' not in params:
-            params['alpha'] = 3
-        # Specific GRF loaders
-        # If making a mask (e.g. land)
-        if name == 'binary_grf':
-            params['binary'] = True
-            if 'min' not in params:
-                params['min'] = 0
-            if 'max' not in params:
-                params['max'] = 1
-            # If threshold not set, make it average of min/max val
-            if 'threshold' not in params:
-                params['threshold'] = 0.5
-        # If making a scalar field
-        elif name == 'scalar_grf':
-            params['binary'] = False
-            if 'min' not in params:
-                params['min'] = -10
-            if 'max' not in params:
-                params['max'] = 10
-            # If threshold not set, make it min/max vals
-            if 'threshold' not in params:
-                params['threshold'] = [0,1]
-            if 'multiplier' not in params:
-                params['multiplier'] = 1
-            if 'offset' not in params:
-                params['offset'] = 0
-        # If making a vector field
-        elif name == 'vector_grf':
-            if 'min' not in params:
-                params['min'] = 0
-            if 'max' not in params:
-                params['max'] = 10
-            if 'vec_x' not in params:
-                params['vec_x'] = 'uC'
-            if 'vec_y' not in params:
-                params['vec_y'] = 'vC'
-                
         return params

--- a/polar_route/dataloaders/scalar/abstract_scalar.py
+++ b/polar_route/dataloaders/scalar/abstract_scalar.py
@@ -36,9 +36,9 @@ class ScalarDataLoader(DataLoaderInterface):
                 Name of scalar variable. Must be the column name if self.data
                 is pd.DataFrame. Must be variable if self.data is xr.Dataset
         '''
-        logging.info(f"Initialising {params['dataloader_name']} dataloader")
         # Translates parameters from config input to desired inputs
-        params = self.add_params(params)
+        params = self.add_default_params(params)
+        logging.info(f"Initialising {params['dataloader_name']} dataloader")
         # Creates a class attribute for all keys in params
         for key, val in params.items():
             setattr(self, key, val)
@@ -96,23 +96,52 @@ class ScalarDataLoader(DataLoaderInterface):
                 Downsampling and reprojecting happen in __init__() method
         '''
         pass
-    
-    def add_params(self, params):
+        
+    def add_default_params(self, params):
         '''
-        Provides option to add parameters before dataloader initialised,
-        useful for translating params from config to specific default 
-        parameters for dataloader. Does nothing by default, but user can
-        overload to add to specific dataloader
+        Set default values for all scalar dataloaders. This function should be
+        overloaded to include any extra params for a specific dataloader
         
         Args:
+            name (str):
+                Name of dataloader entry in dataloader_requirements. Used to
+                specify default parameters for a specific dataloader.
             params (dict): 
-                Dictionary holding keys and values that will be turned into 
-                object attributes
-        
+                Dictionary containing attributes that are required for each 
+                dataloader. 
+            
         Returns:
-            dict:
-                Params dictionary with addition of translated key/value pairs
+            (dict): 
+                Dictionary of attributes the dataloader will require, 
+                completed with default values if not provided in config.
         '''
+        if 'dataloader_name' not in params:
+            params['dataloader_name'] = self.__class__.__name__
+        
+        if 'data_name' not in params:
+            params['data_name'] = None
+
+        if 'downsample_factors' not in params:
+            params['downsample_factors'] = [1,1]
+
+        if 'aggregate_type' not in params: 
+            params['aggregate_type']  = 'MEAN'
+            
+        if 'min_dp' not in params:
+            params['min_dp'] = 5
+            
+        if 'in_proj' not in params:
+            params['in_proj'] = 'EPSG:4326'
+            
+        if 'out_proj' not in params:
+            params['out_proj'] = 'EPSG:4326'
+            
+        if 'x_col' not in params:
+            params['x_col'] = 'lat'
+
+        if 'y_col' not in params:
+            params['y_col'] = 'long'
+            
         return params
 
     def trim_datapoints(self, bounds, data=None):

--- a/polar_route/dataloaders/scalar/amsr.py
+++ b/polar_route/dataloaders/scalar/amsr.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import xarray as xr
 class AMSRDataLoader(ScalarDataLoader):
     
-    def add_params(self, params):
+    def add_default_params(self, params):
         '''
         Translates 'hemisphere' parameter into values of in_proj and out_proj 
         that pyProj can understand. Also defines x_col and y_col for AMSR data
@@ -19,6 +19,8 @@ class AMSRDataLoader(ScalarDataLoader):
             dict:
                 Params dictionary with addition of translated key/value pairs
         '''
+        # Set default parameters same as all other scalar dataloaders
+        params = super().add_default_params(params)
         # Translate 'hemisphere' into initial projection
         hemisphere = params['hemisphere'].lower()
         if  hemisphere == 'north':

--- a/polar_route/dataloaders/scalar/scalar_grf.py
+++ b/polar_route/dataloaders/scalar/scalar_grf.py
@@ -6,6 +6,62 @@ import pandas as pd
 import numpy as np
 
 class ScalarGRFDataLoader(ScalarDataLoader):
+    
+    def add_default_params(self, params):
+        '''
+        Set default values for abstract GRF dataloaders, starting by
+        including defaults for scalar dataloaders.
+        
+        Args:
+            params (dict): 
+                Dictionary containing attributes that are required for the
+                shape being loaded. Must include 'shape'.
+            
+        Returns:
+            (dict): 
+                Dictionary of attributes the dataloader will require, 
+                completed with default values if not provided in config.
+        '''
+        params = super().add_default_params(params)
+        
+        # Params that all GRF dataloaders need
+        if 'seed' not in params:
+            params['seed'] = None
+        if 'size' not in params:
+            params['size'] = 512
+        if 'alpha' not in params:
+            params['alpha'] = 3
+        
+        # Set defaults for binary GRF
+        if params['binary'] == True:
+            if params['data_name'] is None:
+                params['data_name'] = 'binary_data'
+            if 'min' not in params:
+                params['min'] = 0
+            if 'max' not in params:
+                params['max'] = 1
+            # If threshold not set, make it average of min/max val
+            if 'threshold' not in params:
+                params['threshold'] = 0.5
+        # Set defaults for smooth scalar GRF
+        else:
+            if params['data_name'] is None:
+                params['data_name'] = 'scalar_data'
+            if 'min' not in params:
+                params['min'] = -10
+            if 'max' not in params:
+                params['max'] = 10
+            # If threshold not set, make it min/max vals
+            if 'threshold' not in params:
+                params['threshold'] = [0,1]
+            if 'multiplier' not in params:
+                params['multiplier'] = 1
+            if 'offset' not in params:
+                params['offset'] = 0
+                
+        return params
+        
+    
     def import_data(self, bounds):
         '''
         Creates data in the form of a Gaussian Random Field

--- a/polar_route/dataloaders/scalar/shape.py
+++ b/polar_route/dataloaders/scalar/shape.py
@@ -5,6 +5,59 @@ import pandas as pd
 import numpy as np
 
 class ShapeDataLoader(ScalarDataLoader):
+    
+    def add_default_params(self, params):
+        '''
+        Set default values for abstract shape dataloaders, starting by
+        including defaults for scalar dataloaders.
+        
+        Args:
+            params (dict): 
+                Dictionary containing attributes that are required for the
+                shape being loaded. Must include 'shape'.
+            
+        Returns:
+            (dict): 
+                Dictionary of attributes the dataloader will require, 
+                completed with default values if not provided in config.
+        '''
+        # Add default scalar params
+        params = super().add_default_params(params)
+        
+        # Number of datapoints to populate per axis
+        if 'nx' not in params:
+            params['nx'] = 101
+        if 'ny' not in params:
+            params['ny'] = 101
+
+        # Define default circle parameters
+        if params['shape'] == 'circle':
+            if 'radius' not in params:
+                params['radius'] = 1
+            if 'centre' not in params:
+                params['centre'] = (None, None)
+            params['data_generator'] = self.gen_circle
+        # Define default square parameters
+        elif params['shape'] == 'square':
+            if 'side_length' not in params:
+                params['side_length'] = 1
+            if 'centre' not in params:
+                params['centre'] = (None, None)
+            params['data_generator'] = self.gen_square
+        # Define default gradient params
+        elif params['shape'] == 'gradient':
+            if 'vertical' not in params:
+                params['vertical'] = True
+            params['data_generator'] = self.gen_gradient
+        # Define default checkerboard params
+        elif params['shape'] == 'checkerboard':
+            if 'gridsize' not in params:
+                params['gridsize'] = (1,1)
+            params['data_generator'] = self.gen_checkerboard
+            
+        return params
+        
+    
     def import_data(self, bounds):
         '''
         Generates data in the form of an abstract shape, such as circle,
@@ -21,13 +74,9 @@ class ShapeDataLoader(ScalarDataLoader):
                 'dummy_data' (by default)
         '''
         # TODO Move self.lat/long = np.linspace here after reg tests pass
-        # Choose appropriate shape to generate
-        if self.shape == 'circle':
-            data = self.gen_circle(bounds)
-        elif self.shape == 'checkerboard':
-            data = self.gen_checkerboard(bounds)
-        elif self.shape == 'gradient':
-            data = self.gen_gradient(bounds)
+        
+        # Generate abstract data set
+        data = self.data_generator(bounds)
     
         # Fill dummy time values
         data['time'] = bounds.get_time_min()

--- a/polar_route/dataloaders/scalar/shape.py
+++ b/polar_route/dataloaders/scalar/shape.py
@@ -31,29 +31,25 @@ class ShapeDataLoader(ScalarDataLoader):
             params['ny'] = 101
 
         # Define default circle parameters
-        if params['shape'] == 'circle':
+        if params['dataloader_name'] == 'circle':
             if 'radius' not in params:
                 params['radius'] = 1
             if 'centre' not in params:
                 params['centre'] = (None, None)
-            params['data_generator'] = self.gen_circle
         # Define default square parameters
-        elif params['shape'] == 'square':
+        elif params['dataloader_name'] == 'square':
             if 'side_length' not in params:
                 params['side_length'] = 1
             if 'centre' not in params:
                 params['centre'] = (None, None)
-            params['data_generator'] = self.gen_square
         # Define default gradient params
-        elif params['shape'] == 'gradient':
+        elif params['dataloader_name'] == 'gradient':
             if 'vertical' not in params:
                 params['vertical'] = True
-            params['data_generator'] = self.gen_gradient
         # Define default checkerboard params
-        elif params['shape'] == 'checkerboard':
+        elif params['dataloader_name'] == 'checkerboard':
             if 'gridsize' not in params:
                 params['gridsize'] = (1,1)
-            params['data_generator'] = self.gen_checkerboard
             
         return params
         
@@ -74,14 +70,20 @@ class ShapeDataLoader(ScalarDataLoader):
                 'dummy_data' (by default)
         '''
         # TODO Move self.lat/long = np.linspace here after reg tests pass
-        
-        # Generate abstract data set
-        data = self.data_generator(bounds)
-    
-        # Fill dummy time values
-        data['time'] = bounds.get_time_min()
 
-        data_xr = data.set_index(['lat', 'long', 'time']).to_xarray()
+        # Generate abstract data set
+        if self.dataloader_name == 'circle':
+            data = self.gen_circle(bounds)
+        elif self.dataloader_name == 'checkerboard':
+            data = self.gen_checkerboard(bounds)
+        elif self.dataloader_name == 'gradient':
+            data = self.gen_gradient(bounds)
+        else:
+            raise ValueError(
+                f'Unknown abstract shape type: {self.dataloader_name}'
+                )
+
+        data_xr = data.set_index(['lat', 'long']).to_xarray()
         # No need to trim data, as was defined by bounds
 
         return data_xr

--- a/polar_route/dataloaders/vector/abstract_vector.py
+++ b/polar_route/dataloaders/vector/abstract_vector.py
@@ -118,6 +118,7 @@ class VectorDataLoader(DataLoaderInterface):
                 Dictionary of attributes the dataloader will require, 
                 completed with default values if not provided in config.
         '''
+        # This should only pop up if using dataloader not in the factory
         if 'dataloader_name' not in params:
             params['dataloader_name'] = self.__class__.__name__
         
@@ -474,8 +475,7 @@ class VectorDataLoader(DataLoaderInterface):
 
     def get_hom_condition(self, bounds, splitting_conds, agg_type='MEAN'):
         '''
-        Not implemented yet. Retrieves homogeneity condition of data within
-        boundary.
+        Retrieves homogeneity condition of data within boundary. 
          
         Args: 
             bounds (Boundary): Boundary object with limits of datarange to analyse
@@ -484,14 +484,6 @@ class VectorDataLoader(DataLoaderInterface):
                     `(float)` The threshold at which data points of 
                     type 'value' within this CellBox are checked to be either 
                     above or below
-                'upper_bound': 
-                    `(float)` The lowerbound of acceptable percentage 
-                    of data_points of type value within this boundary that are 
-                    above 'threshold'
-                'lower_bound': 
-                    `(float)` The upperbound of acceptable percentage 
-                    of data_points of type value within this boundary that are 
-                    above 'threshold'
 
         Returns:
             str:

--- a/polar_route/dataloaders/vector/abstract_vector.py
+++ b/polar_route/dataloaders/vector/abstract_vector.py
@@ -34,9 +34,9 @@ class VectorDataLoader(DataLoaderInterface):
                 Name of scalar variable. Must be the column name if self.data
                 is pd.DataFrame. Must be variable if self.data is xr.Dataset
         '''
-        logging.info(f"Initialising {params['dataloader_name']} dataloader")
         # Translates parameters from config input to desired inputs
-        params = self.add_params(params)
+        params = self.add_default_params(params)
+        logging.info(f"Initialising {params['dataloader_name']} dataloader")
         # Creates a class attribute for all keys in params
         for key, val in params.items():
             setattr(self, key, val)
@@ -100,22 +100,51 @@ class VectorDataLoader(DataLoaderInterface):
         '''
         pass
     
-    def add_params(self, params):
+    def add_default_params(self, params):
         '''
-        Provides option to add parameters before dataloader initialised,
-        useful for translating params from config to specific default 
-        parameters for dataloader. Does nothing by default, but user can
-        overload to add to specific dataloader
+        Set default values for all scalar dataloaders. This function should be
+        overloaded to include any extra params for a specific dataloader
         
         Args:
+            name (str):
+                Name of dataloader entry in dataloader_requirements. Used to
+                specify default parameters for a specific dataloader.
             params (dict): 
-                Dictionary holding keys and values that will be turned into 
-                object attributes
-        
+                Dictionary containing attributes that are required for each 
+                dataloader. 
+            
         Returns:
-            dict:
-                Params dictionary with addition of translated key/value pairs
+            (dict): 
+                Dictionary of attributes the dataloader will require, 
+                completed with default values if not provided in config.
         '''
+        if 'dataloader_name' not in params:
+            params['dataloader_name'] = self.__class__.__name__
+        
+        if 'data_name' not in params:
+            params['data_name'] = None
+
+        if 'downsample_factors' not in params:
+            params['downsample_factors'] = [1,1]
+
+        if 'aggregate_type' not in params: 
+            params['aggregate_type']  = 'MEAN'
+            
+        if 'min_dp' not in params:
+            params['min_dp'] = 5
+            
+        if 'in_proj' not in params:
+            params['in_proj'] = 'EPSG:4326'
+            
+        if 'out_proj' not in params:
+            params['out_proj'] = 'EPSG:4326'
+            
+        if 'x_col' not in params:
+            params['x_col'] = 'lat'
+
+        if 'y_col' not in params:
+            params['y_col'] = 'long'
+            
         return params
     
     def add_mag_dir(self, data=None, data_names=None):

--- a/polar_route/dataloaders/vector/vector_grf.py
+++ b/polar_route/dataloaders/vector/vector_grf.py
@@ -6,6 +6,47 @@ import pandas as pd
 import numpy as np
 
 class VectorGRFDataLoader(VectorDataLoader):
+
+    def add_default_params(self, params):
+        '''
+        Set default values for abstract GRF dataloaders, starting by
+        including defaults for scalar dataloaders.
+        
+        Args:
+            params (dict): 
+                Dictionary containing attributes that are required for the
+                shape being loaded. Must include 'shape'.
+            
+        Returns:
+            (dict): 
+                Dictionary of attributes the dataloader will require, 
+                completed with default values if not provided in config.
+        '''
+        # Set default vector dataloader params
+        params = super().add_default_params(params)
+        
+        # Params that all GRF dataloaders need
+        if 'seed' not in params:
+            params['seed'] = None
+        if 'size' not in params:
+            params['size'] = 512
+        if 'alpha' not in params:
+            params['alpha'] = 3
+        # Column/variable names
+        if params['data_name'] is None:
+            params['data_name'] = 'uC,vC'
+        if 'vec_x' not in params:
+            params['vec_x'] = params['data_name'].split(',')[0]
+        if 'vec_y' not in params:
+            params['vec_y'] = params['data_name'].split(',')[1]
+        # Min/Max magnitude
+        if 'min' not in params:
+            params['min'] = 0
+        if 'max' not in params:
+            params['max'] = 10
+
+        return params
+        
     def import_data(self, bounds):
         '''
         Creates data in the form of a Gaussian Random Field

--- a/polar_route/mesh_generation/mesh_builder.py
+++ b/polar_route/mesh_generation/mesh_builder.py
@@ -211,7 +211,7 @@ class MeshBuilder:
         
         logging.debug('Adding dataloader')
         dataloader = Dataloader(bounds, params)
-        
+        updated_splitting_cond = []
         if 'splitting_conditions' in params:
             splitting_conds = params['splitting_conditions']
             updated_splitting_cond = [split_cond[dataloader.data_name] for split_cond in splitting_conds]
@@ -233,6 +233,7 @@ class MeshBuilder:
                 cellbox.set_data_source(self.meta_data_list)
         # meta_data_list
         # cellbox.set_data_source
+        return self
         
 
     def validate_bounds(self, bounds, cell_width, cell_height):

--- a/polar_route/mesh_generation/mesh_builder.py
+++ b/polar_route/mesh_generation/mesh_builder.py
@@ -206,6 +206,23 @@ class MeshBuilder:
         return cellboxes
     
     def add_dataloader(self, Dataloader, params, bounds=None, name='myDataLoader', min_dp = 5):
+        '''
+        Adds a dataloader to a pre-existing mesh by adding to the metadata
+        
+        Args:
+            Dataloader (ScalarDataLoader or VectorDataLoader):
+                Dataloader object to add to metadata
+            params (dict):
+                Parameters to initialise dataloader with
+            bounds (Boundary):
+            name (str):
+                Name of the dataloader used in config
+                
+        Returns:
+            MeshBuilder:
+                Original MeshBuilder object (self) with added metadata for 
+                new dataloader
+        '''
         if bounds is None:
             bounds = Boundary.from_json(self.config)
         

--- a/polar_route/mesh_generation/mesh_builder.py
+++ b/polar_route/mesh_generation/mesh_builder.py
@@ -204,6 +204,16 @@ class MeshBuilder:
                     cellbox = CellBox(cell_bounds, cell_id)
                 cellboxes.append(cellbox)
         return cellboxes
+    
+    def add_datapoints(self, Dataloader, params, bounds=None):
+        if bounds is None:
+            bounds = Boundary.from_json(self.config)
+        
+        data_loader = Dataloader(bounds, params)
+        
+        # meta_data_list
+        # cellbox.set_data_source
+        
 
     def validate_bounds(self, bounds, cell_width, cell_height):
         assert (bounds.get_long_max() - bounds.get_long_min()) % cell_width == 0, \


### PR DESCRIPTION
Date: 2023-05-25
Version Number: 0.2.7
 
## Description of change
Added ability to add dataloader to a pre-existing MeshBuilder object. This is designed primarily for external developers who do not wish to edit the repo just to add a new data source. 

## Fixes [ # 143 ](https://github.com/antarctica/SDADT-project/issues/143)

# Testing
- [x] My changes result in all required regression tests passing without the need to update test files.  
  
Modified: polar_route/mesh_generation/mesh_builder.py
[pytest_mesh.txt](https://github.com/antarctica/PolarRoute/files/11566353/pytest_mesh.txt)

# Checklist

- [ ] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `0.2.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   --------
There's a very minor, odd formatting case that I can't find a straight answer for, hence why PEP-8 is not checkmarked here. Line 208 of mesh_builder.py:
'Dataloader' is a class that is passed as an argument, and then gets initialised later in line 230. Sonar complains about the current formatting, but if it was changed to 'dataloader', then line 230 would look like a call to a method instead of initialising a class. 
Just for funsies, I asked ChatGPT, and it says 'According to PEP 8, the Python style guide, there is no specific convention for naming classes that are passed as arguments into a method.' Given that I can't find a convention either, I'm inclined to agree and keep it as is.