### PR TITLE
Fixed mag/dir calculation for  when time is a dimension

### DIFF
--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.10"
+__version__ = "0.2.11"
 __description__ = "PolarRoute: Long-distance maritime polar route planning taking into account complex changing environmental conditions"
 __license__ = "MIT"
 __author__ = "Jonathan Smith, Samuel Hall, George Coombs, Harrison Abbot, Ayat Fekry, James Byrne, Michael Thorne, Maria Fox"

--- a/polar_route/dataloaders/vector/abstract_vector.py
+++ b/polar_route/dataloaders/vector/abstract_vector.py
@@ -180,8 +180,8 @@ class VectorDataLoader(DataLoaderInterface):
                 Same as parent method
             '''
             x, y = names
-            data['magnitude'] = np.linalg.norm([data[x], data[y]], axis=0)
-            data['direction'] = np.arctan(data[y] / data[x])
+            data['_magnitude'] = np.linalg.norm([data[x], data[y]], axis=0)
+            data['_direction'] = np.arctan(data[y] / data[x])
             return data
         
         def add_mag_dir_to_xr(data, names):
@@ -195,12 +195,11 @@ class VectorDataLoader(DataLoaderInterface):
                 Same as parent method
             '''
             x, y = names
-            data = data.assign(
-                _magnitude=lambda l: (['lat', 'long'],
-                                        np.linalg.norm([l[x], l[y]], axis=0)))
-            data = data.assign(
-                _direction=lambda l:(['lat','long'],
-                                        np.arctan(l[y].data / l[x].data)))
+            data['_magnitude'] = (data.dims, 
+                                  np.linalg.norm([data[x].data, data[y].data], 
+                                                 axis=0))
+            data['_direction'] = (data.dims, 
+                                  np.arctan(data[y].data / data[x].data))
             return data
         
         # Set defaults if not passed to method


### PR DESCRIPTION
Date: 2023-06-22
Version Number: 0.2.11
 
## Description of change
@gecoombs  found a bug when writing a new dataloader. This bug crashed the abstract_vector dataloader when it was trying to calculate the magnitude and direction of vectors, if there was a time dimension and the data was loaded as an xarray dataset. This has been fixed so that it should be flexible to any number of dimensions.

## Fixes #198 

# Testing
- [*] My changes have not altered any of the files listed in the testing strategy

- [*] My changes result in all required regression tests passing without the need to update test files.  
  
> `abstract_vector.py` was changed, but is not listed in testing strategy. I ran test_mesh.py as it seems to be the most relevant.
> [pytest_output.txt](https://github.com/antarctica/PolarRoute/files/11834822/pytest_output.txt)


- [ ] My changes require one or more test files to be updated for all regression tests to pass.   

# Checklist

- [*] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [*] I have commented my code, particularly in hard-to-understand areas.  
- [*] I have updated the documentation of the codebase where required.  
- [*] My changes generate no new warnings.   
- [*] My PR has been made to the `0.2.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   