### PR TITLE
GDAL as an optional requirement for 0.2.x

### DIFF
--- a/docs/source/sections/Installation.rst
+++ b/docs/source/sections/Installation.rst
@@ -6,22 +6,10 @@ In this section we will outline the installation steps for installing the softwa
 
 The first stage is installing a version of Python 3.9, if you don't have a working version. We suggest installing a working Anaconda distribution from https://www.anaconda.com/products/distribution#macos following the instructions on that page.
 
-Windows
-#######
-The PolarRoute software requires GDAL files to be installed. The PolarRoute software can be installed on Windows by running one of the two following commands.
+Installing PolarRoute
+#####################
 
-.. note:: 
-    We assume a version of Windows 10 or higher, with a working version of Python 3.9 including pip installed. 
-    We recommend installing PolarRoute into a virtual environment.
-
-Requirements:
-::
-
-    pip install pipwin # pipwin is a package that allows for easy installation of windows binaries
-    pipwin install gdal
-    pipwin install fiona
-
-    pip install -r requirements.txt
+The PolarRoute software can be installed on Windows/Linux/MacOS by running one of the two following commands.
 
 Github:
 ::
@@ -34,18 +22,32 @@ Pip:
 
     pip install polar-route
 
-Linux/MacOS
-###########
-
 
 Installing GDAL
-***************
+###############
 
-Requirements:
+The PolarRoute software has GDAL as an optional requirement. It is only used when exporting TIFF images, 
+so if this is not useful to you, we would recommend steering clear. It is not trivial and is a common source of problems.
+With that said, below are instructions for various operating systems.
 
-.. note::
-    For GDAL (one of the required dependencies for the project), you may try the following 
-    commands to avoid any installation issues:
+Windows
+*******
+
+.. note:: 
+    We assume a version of Windows 10 or higher, with a working version of Python 3.9 including pip installed. 
+    We recommend installing PolarRoute into a virtual environment.
+
+Windows:
+
+::
+
+    pip install pipwin # pipwin is a package that allows for easy installation of windows binaries
+    pipwin install gdal
+    pipwin install fiona
+
+
+Linux/MacOS
+***********
 
 Ubuntu/Debian:
 
@@ -77,26 +79,3 @@ MacOS (with HomeBrew):
     brew install gdal --HEAD
     brew install gdal
     pip install GDAL==$(gdal-config --version)
-
-
-
-Installing PolarRoute
-*********************
-
-The PolarRoute software can be installed on Linux/MacOS by running one of the two following commands.
-
-Github:
-::
-
-    git clone https://https://github.com/antarctica/PolarRoute.git
-    python setup.py install
-
-Pip: 
-::
-
-    pip install polar-route
-
-
-
-
-

--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -3,7 +3,7 @@ __description__ = "PolarRoute: Long-distance maritime polar route planning takin
 __license__ = "MIT"
 __author__ = "Jonathan Smith, Samuel Hall, George Coombs, Harrison Abbot, Ayat Fekry, James Byrne, Michael Thorne, Maria Fox"
 __email__ = "jonsmi@bas.ac.uk"
-__copyright__ = "2023, BAS AI Lab"
+__copyright__ = "2022-2023, BAS AI Lab"
 
 from polar_route.mesh_generation.mesh_builder import MeshBuilder as MeshBuilder
 from polar_route.dataloaders.factory import DataLoaderFactory as DataLoaderFactory

--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -1,9 +1,9 @@
-__version__ = "0.2.11"
+__version__ = "0.2.12"
 __description__ = "PolarRoute: Long-distance maritime polar route planning taking into account complex changing environmental conditions"
 __license__ = "MIT"
 __author__ = "Jonathan Smith, Samuel Hall, George Coombs, Harrison Abbot, Ayat Fekry, James Byrne, Michael Thorne, Maria Fox"
 __email__ = "jonsmi@bas.ac.uk"
-__copyright__ = "2022, BAS AI Lab"
+__copyright__ = "2023, BAS AI Lab"
 
 from polar_route.mesh_generation.mesh_builder import MeshBuilder as MeshBuilder
 from polar_route.dataloaders.factory import DataLoaderFactory as DataLoaderFactory

--- a/polar_route/mesh_generation/environment_mesh.py
+++ b/polar_route/mesh_generation/environment_mesh.py
@@ -16,7 +16,6 @@ from polar_route.mesh_generation.neighbour_graph import NeighbourGraph
 
 
 from polar_route.mesh_validation.sampler import Sampler
-from osgeo import gdal, ogr, osr
 import collections.abc
 import math
 from pathlib import Path
@@ -296,6 +295,7 @@ class EnvironmentMesh:
                 dest.ImportFromEPSG(int(params["projection"]))
                 # transform to target proj and save
                 gdal.Warp(str(path),  str(path), dstSRS=dest.ExportToWkt())
+        
         def set_colour(data, input_file, params):
             """
                   method that changes the color of the generated tif instead of using the default greyscale.
@@ -337,7 +337,9 @@ class EnvironmentMesh:
                 if os.path.isfile (file_path):
                      os.remove(file_path)
 
-
+        # Only import if we need GDAL, to avoid having it as a requirement
+        from osgeo import gdal, ogr, osr
+        
         params = {}
         params = load_params(params_file)
         data_name = params["data_name"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,3 @@ xarray
 shapely
 scikit-learn
 scipy
-gdal


### PR DESCRIPTION
Date: 2023-07-06
Version Number: 0.2.12
## Description of change
Removed need for GDAL by default, instead only requiring it if the user wants to generate TIF's. This enables anyone to use the code without having to go through the headache that is GDAL

## Fixes 
Issue raised in offline discussions

# Testing
This has been tested both on my local computer (with GDAL installed), and on the BAS workstations (without GDAL installed). My computer produces TIFF images, whereas the workstations crash when trying to `export_mesh -f TIF`. This is expected behaviour for me, but I suppose we could handle the crash more elegantly? Thoughts?

- [ ] My changes have not altered any of the files listed in the testing strategy

- [x] My changes result in all required regression tests passing without the need to update test files.  
 
> *Changed environment_mesh.py*
> [Passed tests](https://github.com/antarctica/PolarRoute/files/11950345/pytest_mesh.txt)

- [ ] My changes require one or more test files to be updated for all regression tests to pass.   

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `0.2.x` branch (**DO NOT SUBMIT A PR TO MAIN**) 