### PR TITLE
Reformat geojson output to remove infs

### DIFF
--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.13"
+__version__ = "0.2.14"
 __description__ = "PolarRoute: Long-distance maritime polar route planning taking into account complex changing environmental conditions"
 __license__ = "MIT"
 __author__ = "Jonathan Smith, Samuel Hall, George Coombs, Harrison Abbot, Ayat Fekry, James Byrne, Michael Thorne, Maria Fox"

--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.14"
+__version__ = "0.2.15"
 __description__ = "PolarRoute: Long-distance maritime polar route planning taking into account complex changing environmental conditions"
 __license__ = "MIT"
 __author__ = "Jonathan Smith, Samuel Hall, George Coombs, Harrison Abbot, Ayat Fekry, James Byrne, Michael Thorne, Maria Fox"

--- a/polar_route/cli.py
+++ b/polar_route/cli.py
@@ -168,11 +168,7 @@ def export_mesh_cli():
     if args.format.upper() == "TIF" and  args.output == "export_mesh.output.json": # check if the output file name is not provided set to a defualt name
         args.output = "mesh.tif"
     
-    print(f" Mesh arg = {args.mesh}, format arg = {args.format}")
-    
     logging.info("{} {}".format(inspect.stack()[0][3][:-4], version))
-
-    
 
     mesh = json.load(args.mesh)
 

--- a/polar_route/mesh_generation/environment_mesh.py
+++ b/polar_route/mesh_generation/environment_mesh.py
@@ -153,6 +153,17 @@ class EnvironmentMesh:
 
         # Formatting mesh to geoJSON
         mesh_df = pd.DataFrame(mesh_json['cellboxes'])
+
+        # Average all values stored in list format
+        for column in mesh_df.columns:
+            if column in ['id', 'geometry']:
+                continue
+            elif mesh_df[column].dtype == list:
+                mesh_df[column] = [np.mean(x) for x in mesh_df[column]]
+
+        # Remove infs and replace with nan
+        mesh_df.replace([np.inf, -np.inf], np.nan, inplace=True)
+
         mesh_df['geometry'] = mesh_df['geometry'].apply(wkt.loads)
         mesh_gdf = gpd.GeoDataFrame(
             mesh_df, crs="EPSG:4326", geometry="geometry")
@@ -448,7 +459,7 @@ class EnvironmentMesh:
                     json.dump(self.to_json(), f)
                 elif format.upper() == "GEOJSON":
                     logging.info(f"Saving mesh in {format} format")
-                    json.dump(self.to_geojson(), f)
+                    json.dump(self.to_geojson(), f, indent=4)
                 else:
                     logging.warning(f"Cannot save mesh in a {format} format")
 

--- a/polar_route/mesh_generation/environment_mesh.py
+++ b/polar_route/mesh_generation/environment_mesh.py
@@ -154,15 +154,17 @@ class EnvironmentMesh:
         # Formatting mesh to geoJSON
         mesh_df = pd.DataFrame(mesh_json['cellboxes'])
 
-        # Average all values stored in list format
+        # Average all values stored in list format and drop unnecessary values
         for column in mesh_df.columns:
             if column in ['id', 'geometry']:
                 continue
+            elif column in ['cx', 'cy', 'dcx', 'dcy']:
+                mesh_df = mesh_df.drop(column, axis=1)
             elif mesh_df[column].dtype == list:
                 mesh_df[column] = [np.mean(x) for x in mesh_df[column]]
 
         # Remove infs and replace with nan
-        mesh_df.replace([np.inf, -np.inf], np.nan, inplace=True)
+        mesh_df = mesh_df.replace([np.inf, -np.inf], np.nan)
 
         mesh_df['geometry'] = mesh_df['geometry'].apply(wkt.loads)
         mesh_gdf = gpd.GeoDataFrame(


### PR DESCRIPTION
Date: 13/07/23 
Version Number: 0.2.14 -> 0.2.15
 
## Description of change
Change the function that exports a mesh to geojson to average list values and remove infs and replace then with null values.

## Fixes 
https://github.com/antarctica/SDADT-project/issues/147

# Testing

- [x] My changes result in all required regression tests passing without the need to update test files.  

Test dump:

[pytest_dump.txt](https://github.com/antarctica/PolarRoute/files/12039616/pytest_dump.txt)

Changed:
`polar_route/mesh_generation/environment_mesh.py`


# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `0.2.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
