### PR TITLE
Dijkstra convergence error

### DIFF
--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.15"
+__version__ = "0.2.16"
 __description__ = "PolarRoute: Long-distance maritime polar route planning taking into account complex changing environmental conditions"
 __license__ = "MIT"
 __author__ = "Jonathan Smith, Samuel Hall, George Coombs, Harrison Abbot, Ayat Fekry, James Byrne, Michael Thorne, Maria Fox"

--- a/polar_route/crossing.py
+++ b/polar_route/crossing.py
@@ -9,6 +9,7 @@ import copy
 import pandas as pd
 import numpy as np
 import pyproj
+import logging
 np.seterr(divide='ignore', invalid='ignore')
 
 
@@ -84,30 +85,32 @@ class NewtonianDistance:
         self.debugging     = debugging
 
     def _newton_optimisation(self, f, x, a, Y, u1, v1, u2, v2, s1, s2):
-        '''
-            FILL
-        '''
+        """
+            Find the y value of the crossing point and travel time in each cell using the Newton method
+        """
         y0 = (Y*x)/(x+a)
         if self.debugging:
             print('---Initial y={:.2f}'.format(y0))
         improving = True
-        iterartion_num = 0
+        iteration_num = 0
         while improving:
-            F,dF,X1,X2,t1,t2  = f(y0,x,a,Y,u1,v1,u2,v2,s1,s2)
-            if F==np.inf:
-                return np.nan,np.inf  
+            F, dF, X1, X2, t1, t2  = f(y0,x,a,Y,u1,v1,u2,v2,s1,s2)
+            if F == np.inf:
+                return np.nan, np.inf
 
             if self.debugging:
                 print('---Iteration {}: y={:.2f}; F={:.5f}; dF={:.2f}'\
-                      .format(iterartion_num,y0,F,dF))
+                      .format(iteration_num, y0, F, dF))
             y0  = y0 - (F/dF)
             improving = abs((F/dF)/(X1*X2)) > self.optimizer_tol
-            iterartion_num+=1
-            if iterartion_num>1000:
-                raise Exception('Newton not able to converge')
-            
+            iteration_num += 1
+            if iteration_num > 1000:
+                y0 = np.nan
+                t1 = np.inf
+                t2 = np.inf
+                logging.debug("Newton not able to converge: setting travel time to infinity")
 
-        return y0,self._unit_time(np.array([t1,t2]))
+        return y0, self._unit_time(np.array([t1,t2]))
 
     def _unit_speed(self,val):
         '''

--- a/polar_route/crossing.py
+++ b/polar_route/crossing.py
@@ -104,7 +104,9 @@ class NewtonianDistance:
             y0  = y0 - (F/dF)
             improving = abs((F/dF)/(X1*X2)) > self.optimizer_tol
             iteration_num += 1
+            # Assume convergence impossible after 1000 iterations and exit
             if iteration_num > 1000:
+                # Set crossing point to nan and travel times to infinity
                 y0 = np.nan
                 t1 = np.inf
                 t2 = np.inf


### PR DESCRIPTION
Date: 18/07/23
Version Number: 0.2.15 -> 0.2.16
 
## Description of change
This PR fixes an issue where if the Dijsktra route construction reached a point where it could not converge it simply exited with an exception. It now sets the cost of visiting that point to infinity and tries alternative paths.

## Fixes #211 

# Testing

- [x] My changes result in all required regression tests passing without the need to update test files.  
  
Files changed:
`polar_route/crossing.py`

Test dump:
[pytest_dump.txt](https://github.com/antarctica/PolarRoute/files/12082953/pytest_dump.txt)


# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `0.2.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  
