### PR TITLE
Wave dataloaders

### DIFF
--- a/docs/source/sections/Dataloaders/scalar/implemented/ERA5WaveHeight.rst
+++ b/docs/source/sections/Dataloaders/scalar/implemented/ERA5WaveHeight.rst
@@ -1,0 +1,22 @@
+***************************
+ERA5 Wave Height Dataloader
+***************************
+
+ERA5 is a family of data products produced by the European Centre for Medium-Range Weather Forecasts (ECMWF).
+It is the fifth generation ECMWF atmospheric reanalysis of the global climate covering the period from January 1950 to present.
+
+From their website:
+
+   ERA5 provides hourly estimates of a large number of atmospheric,
+   land and oceanic climate variables. The data cover the Earth on a
+   30km grid and resolve the atmosphere using 137 levels from the
+   surface up to a height of 80km. ERA5 includes information about
+   uncertainties for all variables at reduced spatial and temporal resolutions.
+
+Instructions for how to download their data products are
+available `here <https://confluence.ecmwf.int/display/CKB/How+to+download+ERA5>`_
+
+
+.. automodule:: polar_route.dataloaders.scalar.era5_wave_height
+   :special-members: __init__
+   :members:

--- a/docs/source/sections/Dataloaders/vector/implemented/ERA5WaveDirection.rst
+++ b/docs/source/sections/Dataloaders/vector/implemented/ERA5WaveDirection.rst
@@ -16,6 +16,9 @@ From their website:
 Instructions for how to download their data products are 
 available `here <https://confluence.ecmwf.int/display/CKB/How+to+download+ERA5>`_
 
+This dataloader takes the mean wave direction variable, which gives the direction the waves are coming from as an angle
+from north in degrees, and converts it to a unit vector with u and v components.
+
 
 .. automodule:: polar_route.dataloaders.vector.era5_wave_direction
    :special-members: __init__

--- a/docs/source/sections/Dataloaders/vector/implemented/ERA5WaveDirection.rst
+++ b/docs/source/sections/Dataloaders/vector/implemented/ERA5WaveDirection.rst
@@ -1,0 +1,22 @@
+******************************
+ERA5 Wave Direction Dataloader
+******************************
+
+ERA5 is a family of data products produced by the European Centre for Medium-Range Weather Forecasts (ECMWF).
+It is the fifth generation ECMWF atmospheric reanalysis of the global climate covering the period from January 1950 to present.
+
+From their website:
+
+   ERA5 provides hourly estimates of a large number of atmospheric, 
+   land and oceanic climate variables. The data cover the Earth on a 
+   30km grid and resolve the atmosphere using 137 levels from the 
+   surface up to a height of 80km. ERA5 includes information about 
+   uncertainties for all variables at reduced spatial and temporal resolutions.
+
+Instructions for how to download their data products are 
+available `here <https://confluence.ecmwf.int/display/CKB/How+to+download+ERA5>`_
+
+
+.. automodule:: polar_route.dataloaders.vector.era5_wave_direction
+   :special-members: __init__
+   :members:

--- a/polar_route/dataloaders/factory.py
+++ b/polar_route/dataloaders/factory.py
@@ -8,6 +8,7 @@ from polar_route.dataloaders.scalar.modis import MODISDataLoader
 from polar_route.dataloaders.scalar.scalar_csv import ScalarCSVDataLoader
 from polar_route.dataloaders.scalar.scalar_grf import ScalarGRFDataLoader
 from polar_route.dataloaders.scalar.shape import ShapeDataLoader
+from polar_route.dataloaders.scalar.era5_wave_height import ERA5WaveHeightDataLoader
 
 from polar_route.dataloaders.vector.baltic_current import BalticCurrentDataLoader
 from polar_route.dataloaders.vector.era5_wind import ERA5WindDataLoader
@@ -17,6 +18,7 @@ from polar_route.dataloaders.vector.sose import SOSEDataLoader
 from polar_route.dataloaders.vector.vector_csv import VectorCSVDataLoader
 from polar_route.dataloaders.vector.vector_grf import VectorGRFDataLoader
 from polar_route.dataloaders.vector.duacs_current import DuacsCurrentDataLoader
+from polar_route.dataloaders.vector.era5_wave_direction import ERA5WaveDirectionLoader
 
 from polar_route.dataloaders.scalar.density import DensityDataLoader
 from polar_route.dataloaders.scalar.thickness import ThicknessDataLoader
@@ -41,7 +43,8 @@ class DataLoaderFactory:
                 'bsose_depth', 'baltic_sic', 'gebco', 'icenet', 'modis',
                 'thickness', 'density', 'circle', 'square', 'gradient',
                 'checkerboard', 'vector_csv', 'vector_grf', 'baltic_currents',
-                'era5_wind', 'northsea_currents', 'oras5_currents', 'sose'
+                'era5_wind', 'northsea_currents', 'oras5_currents', 'sose',
+                'duacs_currents', 'era5_wave_height', 'era5_wave_direction'
             bounds (Boundary):
                 Boundary object with initial mesh space&time limits
             params (dict):
@@ -74,6 +77,7 @@ class DataLoaderFactory:
             'gebco':        (GEBCODataLoader, ['files']),
             'icenet':       (IceNetDataLoader, ['files']),
             'modis':        (MODISDataLoader, ['files']),
+            'era5_wave_height': (ERA5WaveHeightDataLoader, ['files']),
             'thickness':    (ThicknessDataLoader, []),
             'density':      (DensityDataLoader, []),
             # Scalar - Abstract shapes
@@ -86,6 +90,7 @@ class DataLoaderFactory:
             'vector_grf':       (VectorGRFDataLoader, []),
             'baltic_currents':  (BalticCurrentDataLoader, ['files']),
             'era5_wind':        (ERA5WindDataLoader, ['files']),
+            'era5_wave_direction': (ERA5WaveDirectionLoader, ['files']),
             'northsea_currents':(NorthSeaCurrentDataLoader, ['files']),
             'duacs_currents':     (DuacsCurrentDataLoader, ['files']),
             'oras5_currents':   (ORAS5CurrentDataLoader, ['files']),

--- a/polar_route/dataloaders/scalar/bsose_depth.py
+++ b/polar_route/dataloaders/scalar/bsose_depth.py
@@ -4,19 +4,19 @@ import xarray as xr
 
 class BSOSEDepthDataLoader(ScalarDataLoader):
     def import_data(self, bounds):
-        '''
-        Reads in data from a BSOSE Depth NetCDF file. 
-        Renames coordinates to 'lat' and 'long', and renames variable to 
+        """
+        Reads in data from a BSOSE Depth NetCDF file.
+        Renames coordinates to 'lat' and 'long', and renames variable to
         'elevation'
-        
+
         Args:
             bounds (Boundary): Initial boundary to limit the dataset to
-            
+
         Returns:
-            xr.Dataset: 
-                BSOSE Depth dataset within limits of bounds. 
+            xr.Dataset:
+                BSOSE Depth dataset within limits of bounds.
                 Dataset has coordinates 'lat', 'long', and variable 'elevation'
-        '''
+        """
         # Open Dataset
         if len(self.files) == 1:    data = xr.open_dataset(self.files[0])
         else:                       data = xr.open_mfdataset(self.files)
@@ -25,7 +25,7 @@ class BSOSEDepthDataLoader(ScalarDataLoader):
                             'YC': 'lat',
                             'XC': 'long'})
         # Change domain of dataset from [0:360) to [-180:180)
-        data = data.assign_coords(long=((da.lon + 180) % 360) - 180)
+        data = data.assign_coords(long=((data.long + 180) % 360) - 180)
         # Trim to initial datapoints
         data = self.trim_datapoints(bounds, data=data)
         

--- a/polar_route/dataloaders/scalar/bsose_depth.py
+++ b/polar_route/dataloaders/scalar/bsose_depth.py
@@ -26,6 +26,14 @@ class BSOSEDepthDataLoader(ScalarDataLoader):
                             'XC': 'long'})
         # Change domain of dataset from [0:360) to [-180:180)
         data = data.assign_coords(long=((data.long + 180) % 360) - 180)
+        # Sort the 'long' axis so that sel() will work
+        data = data.sortby('long')
+        # Convert elevation from coord to variable
+        data = data.reset_coords('elevation')
+        # Convert depth to elevation by inverting sign
+        data['elevation'] = -1 * data['elevation']
+        # Limit to just elevation data
+        data = data['elevation'].to_dataset()
         # Trim to initial datapoints
         data = self.trim_datapoints(bounds, data=data)
         

--- a/polar_route/dataloaders/scalar/bsose_sea_ice.py
+++ b/polar_route/dataloaders/scalar/bsose_sea_ice.py
@@ -22,7 +22,7 @@ class BSOSESeaIceDataLoader(ScalarDataLoader):
         Raises:
             ValueError:
                 If units specified in config,
-                and value not 'fraction' or 'percentage
+                and value not 'fraction' or 'percentage'
         """
         logging.info(f"- Opening file {self.file}")
         # Open Dataset

--- a/polar_route/dataloaders/scalar/bsose_sea_ice.py
+++ b/polar_route/dataloaders/scalar/bsose_sea_ice.py
@@ -6,24 +6,24 @@ import xarray as xr
 
 class BSOSESeaIceDataLoader(ScalarDataLoader):
     def import_data(self, bounds):
-        '''
-        Reads in data from a BSOSE Sea Ice NetCDF file. 
-        Renames coordinates to 'lat' and 'long', and renames variable to 
+        """
+        Reads in data from a BSOSE Sea Ice NetCDF file.
+        Renames coordinates to 'lat' and 'long', and renames variable to
         'SIC'
-        
+
         Args:
             bounds (Boundary): Initial boundary to limit the dataset to
-            
+
         Returns:
-            xr.Dataset: 
-                BSOSE Sea Ice dataset within limits of bounds. 
+            xr.Dataset:
+                BSOSE Sea Ice dataset within limits of bounds.
                 Dataset has coordinates 'lat', 'long', and variable 'SIC'
-                
+
         Raises:
-            ValueError: 
-                If units specified in config, 
+            ValueError:
+                If units specified in config,
                 and value not 'fraction' or 'percentage
-        '''
+        """
         logging.info(f"- Opening file {self.file}")
         # Open Dataset
         if len(self.files) == 1:    data = xr.open_dataset(self.files[0])
@@ -48,7 +48,7 @@ class BSOSESeaIceDataLoader(ScalarDataLoader):
             elif self.units == 'fraction':
                 pass # BSOSE data already in fraction form
             else:
-                raise ValueError("Parameter 'units' not understood."\
-                                 "Expected 'percentage' or 'fraction',"\
-                                f"but recieved {self.units}")
+                raise ValueError("Parameter 'units' not understood."
+                                 "Expected 'percentage' or 'fraction',"
+                                f"but received {self.units}")
         return data

--- a/polar_route/dataloaders/scalar/era5_wave_height.py
+++ b/polar_route/dataloaders/scalar/era5_wave_height.py
@@ -1,0 +1,33 @@
+from polar_route.dataloaders.scalar.abstract_scalar import ScalarDataLoader
+
+import xarray as xr
+
+
+class ERA5WaveHeightDataLoader(ScalarDataLoader):
+    def import_data(self, bounds):
+        """
+        Reads in data from an ERA5 NetCDF file.
+        Renames coordinates to 'lat' and 'long'
+
+        Args:
+            bounds (Boundary): Initial boundary to limit the dataset to
+
+        Returns:
+            xr.Dataset:
+                ERA5 wave dataset within limits of bounds.
+                Dataset has coordinates 'lat', 'long', and variable 'swh'
+        """
+        # Open Dataset
+        if len(self.files) == 1:    data = xr.open_dataset(self.files[0])
+        else:                       data = xr.open_mfdataset(self.files)
+        # Change column names
+        data = data.rename({'longitude': 'lat',
+                            'latitude': 'long'})
+        # Limit to just swh data
+        data = data['swh'].to_dataset()
+        # Reverse order of lat as array goes from max to min
+        data = data.reindex(lat=data.lat[::-1])
+        # Trim to initial datapoints
+        data = self.trim_datapoints(bounds, data=data)
+        
+        return data

--- a/polar_route/dataloaders/scalar/era5_wave_height.py
+++ b/polar_route/dataloaders/scalar/era5_wave_height.py
@@ -21,8 +21,12 @@ class ERA5WaveHeightDataLoader(ScalarDataLoader):
         if len(self.files) == 1:    data = xr.open_dataset(self.files[0])
         else:                       data = xr.open_mfdataset(self.files)
         # Change column names
-        data = data.rename({'longitude': 'lat',
-                            'latitude': 'long'})
+        data = data.rename({'latitude': 'lat',
+                            'longitude': 'long'})
+        # Change domain of dataset from [0:360) to [-180:180)
+        data = data.assign_coords(long=((data.long + 180) % 360) - 180)
+        # Sort the 'long' axis so that sel() will work
+        data = data.sortby('long')
         # Limit to just swh data
         data = data['swh'].to_dataset()
         # Reverse order of lat as array goes from max to min

--- a/polar_route/dataloaders/vector/era5_wave_direction.py
+++ b/polar_route/dataloaders/vector/era5_wave_direction.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from polar_route.dataloaders.vector.abstract_vector import VectorDataLoader
 
 import logging
@@ -6,19 +8,20 @@ import xarray as xr
 
 from datetime import datetime
 
-class ERA5WindDataLoader(VectorDataLoader):
+class ERA5WaveDirectionLoader(VectorDataLoader):
     def import_data(self, bounds):
         """
-        Reads in wind data from a ERA5 NetCDF file.
-        Renames coordinates to 'lat' and 'long'
+        Reads in wave direction data from a ERA5 NetCDF file.
+        Renames coordinates to 'lat' and 'long' and calculates unit vector
+        from mean wave direction variable 'mwd'.
 
         Args:
             bounds (Boundary): Initial boundary to limit the dataset to
 
         Returns:
             xr.Dataset:
-                ERA5 wind dataset within limits of bounds.
-                Dataset has coordinates 'lat', 'long', and variables 'u10', 'v10'
+                ERA5 wave dataset within limits of bounds.
+                Dataset has coordinates 'lat', 'long', and variables 'uW', 'vW'
         """
         # Open Dataset
         if len(self.files) == 1:    data = xr.open_dataset(self.files[0])
@@ -26,6 +29,9 @@ class ERA5WindDataLoader(VectorDataLoader):
         # Change column names
         data = data.rename({'latitude': 'lat',
                             'longitude': 'long'})
+
+        data['uW'] = -1 * np.sin(data['mwd'])
+        data['vW'] = -1 * np.cos(data['mwd'])
 
         # Set min time to start of month to ensure we include data as we only have a
         # monthly cadence. Assuming time is in str format

--- a/polar_route/dataloaders/vector/era5_wave_direction.py
+++ b/polar_route/dataloaders/vector/era5_wave_direction.py
@@ -30,8 +30,18 @@ class ERA5WaveDirectionLoader(VectorDataLoader):
         data = data.rename({'latitude': 'lat',
                             'longitude': 'long'})
 
+        # Change domain of dataset from [0:360) to [-180:180)
+        data = data.assign_coords(long=((data.long + 180) % 360) - 180)
+        # Sort the 'long' axis so that sel() will work
+        data = data.sortby('long')
+
+        # Convert direction in degrees to u and v components
+        data['mwd'] = np.radians(data['mwd'])
         data['uW'] = -1 * np.sin(data['mwd'])
         data['vW'] = -1 * np.cos(data['mwd'])
+
+        # Limit to just uW and vW
+        data = data[['uW', 'vW']]
 
         # Set min time to start of month to ensure we include data as we only have a
         # monthly cadence. Assuming time is in str format


### PR DESCRIPTION
Date: 25/07/23 
Version Number: 0.3.0
 
## Description of change
Adds dataloaders for significant wave height and mean wave direction (as a unit vector) from ERA5 reanalysis data.

## Fixes #161 

# Testing

- [x] My changes have not altered any of the files listed in the testing strategy

Files changed:

```
docs/source/sections/Dataloaders/scalar/implemented/ERA5WaveHeight.rst
docs/source/sections/Dataloaders/vector/implemented/ERA5WaveDirection.rst
polar_route/dataloaders/factory.py
polar_route/dataloaders/scalar/bsose_depth.py
polar_route/dataloaders/scalar/bsose_sea_ice.py
polar_route/dataloaders/scalar/era5_wave_height.py
polar_route/dataloaders/vector/era5_wave_direction.py
polar_route/dataloaders/vector/era5_wind.py
```

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `0.3.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  
