### PR TITLE
Geojson smoothed route fix

### DIFF
--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.20"
+__version__ = "0.2.21"
 __description__ = "PolarRoute: Long-distance maritime polar route planning taking into account complex changing environmental conditions"
 __license__ = "MIT"
 __author__ = "Jonathan Smith, Samuel Hall, George Coombs, Harrison Abbot, Ayat Fekry, James Byrne, Michael Thorne, Maria Fox"

--- a/polar_route/route_planner.py
+++ b/polar_route/route_planner.py
@@ -670,7 +670,8 @@ class RoutePlanner:
             SmoothedPath['properties']['distance']   = list(DistanceLegs)
             SmoothedPath['properties']['speed']      = list(SpeedLegs)
             SmoothedPaths += [SmoothedPath]
-        
+
+        geojson['type'] = "FeatureCollection"
         geojson['features'] = SmoothedPaths
         self.smoothed_paths = geojson
         self.mesh['paths'] = self.smoothed_paths


### PR DESCRIPTION
# PolarRoute Pull Request 224

Date: 21/08/23
Version Number: 0.2.20 -> 0.2.21
 
## Description of change
Fixes an issue with the format of smoothed routes, which were no longer valid geojson.

## Fixes #223 

# Testing

- [x] My changes result in all required regression tests passing without the need to update test files.  
  
Files changed:
```
polar_route/route_planner.py
```
Test results:  [smoothing_test_dump.txt](https://github.com/antarctica/PolarRoute/files/12395528/smoothing_test_dump.txt)

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   