### PR TITLE
Exclusion zone vessel performance

### DIFF
--- a/docs/source/sections/Configuration/Vessel_performance_config.rst
+++ b/docs/source/sections/Configuration/Vessel_performance_config.rst
@@ -17,7 +17,9 @@ the 'add_vehicle' entry point.
      "hull_type": "slender",
      "force_limit": 96634.5,
      "max_ice_conc": 80,
-     "min_depth": 10
+     "min_depth": 10,
+     "max_wave": 3,
+     "excluded_zones": ["exclusion_zone"]
    }
 
 Above are a typical set of configuration parameters used for a vessel where the variables are as follows:
@@ -30,3 +32,5 @@ Above are a typical set of configuration parameters used for a vessel where the 
 * **force_limit** *(float)* : The maximum allowed resistance force, specified in Newtons.
 * **max_ice_conc** *(float)* : The maximum Sea Ice Concentration the vessel is able to travel through given as a percentage.
 * **min_depth** *(float)* : The minimum depth of water the vessel is able to travel through in metres.
+* **max_wave** *(float)* : The maximum significant wave height the vessel is able to travel through in metres.
+* **excluded_zones** *(float)* : A list of of strings that name different boolean properties of a cell. Any cell with a value of True for any of the entered keys will be marked as unnavigable.

--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.4"
+__version__ = "0.3.5"
 __description__ = "PolarRoute: Long-distance maritime polar route planning taking into account complex changing environmental conditions"
 __license__ = "MIT"
 __author__ = "Jonathan Smith, Samuel Hall, George Coombs, Harrison Abbot, Ayat Fekry, James Byrne, Michael Thorne, Maria Fox"

--- a/polar_route/vessel_performance/vessels/abstract_glider.py
+++ b/polar_route/vessel_performance/vessels/abstract_glider.py
@@ -19,6 +19,7 @@ class AbstractGlider(AbstractVessel):
         self.speed_unit = self.vessel_params['Unit']
         self.max_elevation = -1 * self.vessel_params['MinDepth']
         self.max_ice = self.vessel_params['MaxIceConc']
+        self.excluded_zones = self.vessel_params.get('excluded_zones')
 
 
     def model_performance(self, cellbox):
@@ -50,9 +51,15 @@ class AbstractGlider(AbstractVessel):
                       f"{self.vessel_params['VesselType']}")
         access_values = dict()
 
+        # Exclude cells due to land or ice
         access_values['land'] = self.land(cellbox)
         access_values['shallow'] = self.shallow(cellbox)
         access_values['ext_ice'] = self.extreme_ice(cellbox)
+
+        # Exclude any other cell types specified in config
+        if self.excluded_zones is not None:
+            for zone in self.excluded_zones:
+                access_values[zone] = cellbox.agg_data[zone]
 
         access_values['inaccessible'] = any(access_values.values())
 

--- a/polar_route/vessel_performance/vessels/abstract_glider.py
+++ b/polar_route/vessel_performance/vessels/abstract_glider.py
@@ -14,11 +14,11 @@ class AbstractGlider(AbstractVessel):
                 params (dict): vessel parameters from the vessel config file
         """
         self.vessel_params = params
-        logging.info(f"Initialising a vessel object of type: {self.vessel_params['VesselType']}")
-        self.max_speed = self.vessel_params['MaxSpeed']
-        self.speed_unit = self.vessel_params['Unit']
-        self.max_elevation = -1 * self.vessel_params['MinDepth']
-        self.max_ice = self.vessel_params['MaxIceConc']
+        logging.info(f"Initialising a vessel object of type: {self.vessel_params['vessel_type']}")
+        self.max_speed = self.vessel_params['max_speed']
+        self.speed_unit = self.vessel_params['unit']
+        self.max_elevation = -1 * self.vessel_params['min_depth']
+        self.max_ice = self.vessel_params['max_ice_conc']
         self.excluded_zones = self.vessel_params.get('excluded_zones')
 
 
@@ -30,7 +30,7 @@ class AbstractGlider(AbstractVessel):
                     cellbox (AggregatedCellBox): input cell from environmental mesh
         """
         logging.debug(
-            f"Modelling performance in cell {cellbox.id} for a vessel of type: {self.vessel_params['VesselType']}")
+            f"Modelling performance in cell {cellbox.id} for a vessel of type: {self.vessel_params['vessel_type']}")
         perf_cellbox = self.model_speed(cellbox)
         perf_cellbox = self.model_battery(perf_cellbox)
 
@@ -48,7 +48,7 @@ class AbstractGlider(AbstractVessel):
                 access_values (dict): boolean values for the modelled accessibility criteria
         """
         logging.debug(f"Modelling accessibility in cell {cellbox.id} for a vessel of type: "
-                      f"{self.vessel_params['VesselType']}")
+                      f"{self.vessel_params['vessel_type']}")
         access_values = dict()
 
         # Exclude cells due to land or ice


### PR DESCRIPTION
# PolarRoute Pull Request

Date:  03/10/23
Version Number: 0.3.4 -> 0.3.5
 
## Description of change
Modify vessel performance code to allow arbitrarily named exclusion zones to be entered into the config and cells marked with those labels to be excluded from the neighbour graph.

## Fixes #229 

# Testing

- [x] My changes result in all required regression tests passing without the need to update test files.  
  
Files changed:

```
docs/source/sections/Configuration/Vessel_performance_config.rst
polar_route/__init__.py
polar_route/vessel_performance/vessels/abstract_glider.py
polar_route/vessel_performance/vessels/abstract_ship.py
```
Test dump:
[vessel_test_dump.txt](https://github.com/antarctica/PolarRoute/files/12793000/vessel_test_dump.txt)

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `0.3.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
