### PR TITLE
Add in total traveltime and fuel properties to route output

### DIFF
--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 __description__ = "PolarRoute: Long-distance maritime polar route planning taking into account complex changing environmental conditions"
 __license__ = "MIT"
 __author__ = "Jonathan Smith, Samuel Hall, George Coombs, Harrison Abbot, Ayat Fekry, James Byrne, Michael Thorne, Maria Fox"

--- a/polar_route/route_planner.py
+++ b/polar_route/route_planner.py
@@ -460,7 +460,9 @@ class RoutePlanner:
                                                   index=variable_vals.index)
                             variable_diff = traveltime_diff*case_vals
                             path['properties'][vrbl] = np.cumsum(variable_diff.to_numpy()).tolist()
+                            path['properties']['total_'+vrbl] = path['properties'][vrbl][-1]
                         path['properties']['traveltime'] = path['properties']['traveltime'].tolist()
+                        path['properties']['total_traveltime'] = path['properties']['traveltime'][-1]
                         paths.append(path)
 
                     except:
@@ -666,7 +668,9 @@ class RoutePlanner:
             SmoothedPath['properties']['from']       = route['properties']['from']
             SmoothedPath['properties']['to']         = route['properties']['to']
             SmoothedPath['properties']['traveltime'] = list(TravelTimeLegs)
+            SmoothedPath['properties']['total_traveltime'] = SmoothedPath['properties']['traveltime'][-1]
             SmoothedPath['properties']['fuel']       = list(FuelLegs)
+            SmoothedPath['properties']['total_fuel'] = SmoothedPath['properties']['fuel'][-1]
             SmoothedPath['properties']['distance']   = list(DistanceLegs)
             SmoothedPath['properties']['speed']      = list(SpeedLegs)
             SmoothedPaths += [SmoothedPath]


### PR DESCRIPTION
# PolarRoute Pull Request

Date: 05/10/23
Version Number: 0.3.6
 
## Description of change
Add in single value properties for the total fuel and travel time to the geojson route output for easy display in GIS software.

## Fixes [#115](https://github.com/antarctica/AMOP-project/issues/115)

# Testing

- [x] My changes result in all required regression tests passing without the need to update test files.  
  
Files changed:
```
polar_route/__init__.py
polar_route/route_planner.py
```
Test dump: 
[route_test_dump.txt](https://github.com/antarctica/PolarRoute/files/12817045/route_test_dump.txt)


# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `0.3.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
