### PR TITLE
Fixing version limits

### DIFF
--- a/polar_route/route_planner.py
+++ b/polar_route/route_planner.py
@@ -11,9 +11,8 @@ from shapely import wkt, Point, LineString, STRtree, Polygon
 import geopandas as gpd
 import logging
 
-# from pandas.core.common import SettingWithCopyWarning
-# warnings.simplefilter(action="ignore", category=SettingWithCopyWarning)
-# pd.options.mode.chained_assignment = None
+# Squelching SettingWithCopyWarning 
+pd.options.mode.chained_assignment = None
 
 from polar_route.crossing import NewtonianDistance
 from polar_route.crossing_smoothing import Smoothing,PathValues,find_edge

--- a/polar_route/route_planner.py
+++ b/polar_route/route_planner.py
@@ -10,6 +10,7 @@ from tqdm import tqdm
 from shapely import wkt, Point, LineString, STRtree, Polygon
 import geopandas as gpd
 import logging
+from io import StringIO  
 
 # Squelching SettingWithCopyWarning 
 pd.options.mode.chained_assignment = None
@@ -413,7 +414,7 @@ class RoutePlanner:
         self.mesh['waypoints'] =  self.mesh['waypoints'].to_json()
 
         # ==== Printing Configuration and Information
-        self.mesh['waypoints'] =  pd.read_json(self.mesh['waypoints'])
+        self.mesh['waypoints'] =  pd.read_json(StringIO(self.mesh['waypoints']))
 
         # # ===== Running the route planner for the given information
         # if ("dijkstra_only" in self.config) and self.config['dijkstra_only']:

--- a/polar_route/route_planner.py
+++ b/polar_route/route_planner.py
@@ -311,8 +311,8 @@ class RoutePlanner:
 
             adjusted_point = _adjust_waypoints(point, self.mesh['cellboxes'])
             
-            waypoints_df['Long'][idx] = adjusted_point.x
-            waypoints_df['Lat'][idx] = adjusted_point.y
+            waypoints_df.loc[idx, 'Long'] = adjusted_point.x
+            waypoints_df.loc[idx, 'Lat'] = adjusted_point.y
         
         source_waypoints_df   = waypoints_df[waypoints_df['Source'] == "X"]
         des_waypoints_df      = waypoints_df[waypoints_df['Destination'] == "X"]
@@ -406,7 +406,7 @@ class RoutePlanner:
             if len(indices) > 1:
                 raise Exception('Waypoint lies in multiple cell boxes. Please check mesh ! ')
             else:
-                wpts['index'].loc[idx] = int(indices[0])
+                wpts.loc[idx, 'index'] = int(indices[0])
 
         self.mesh['waypoints'] = wpts[~wpts['index'].isnull()]
         self.mesh['waypoints']['index'] = self.mesh['waypoints']['index'].astype(int)

--- a/polar_route/route_planner.py
+++ b/polar_route/route_planner.py
@@ -671,7 +671,7 @@ class RoutePlanner:
         wpts = self.mesh['waypoints'][self.mesh['waypoints']['Name'].isin(self.end_waypoints)]
         
         # Initialising zero traveltime at the source location
-        source_index = int(self.mesh['waypoints'][self.mesh['waypoints']['Name'] == wpt_name]['index'])
+        source_index = int(self.mesh['waypoints'][self.mesh['waypoints']['Name'] == wpt_name]['index'].iloc[0])
 
         for vrbl in self.config['path_variables']:
             self.dijkstra_info[wpt_name].loc[source_index, 'shortest_{}'.format(vrbl)] = 0.0

--- a/polar_route/route_planner.py
+++ b/polar_route/route_planner.py
@@ -11,8 +11,9 @@ from shapely import wkt, Point, LineString, STRtree, Polygon
 import geopandas as gpd
 import logging
 
-from pandas.core.common import SettingWithCopyWarning
-warnings.simplefilter(action="ignore", category=SettingWithCopyWarning)
+# from pandas.core.common import SettingWithCopyWarning
+# warnings.simplefilter(action="ignore", category=SettingWithCopyWarning)
+# pd.options.mode.chained_assignment = None
 
 from polar_route.crossing import NewtonianDistance
 from polar_route.crossing_smoothing import Smoothing,PathValues,find_edge

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ jsonschema
 matplotlib
 netcdf4
 numpy>=1.21.6
-pandas>=1.3.5,<1.5
+pandas>=1.3.5
 pyproj
 pytest
 shapely


### PR DESCRIPTION
# PolarRoute Pull Request Template

Date: 2024-03-26
Version Number: 0.4.0
 
## Description of change
Fixing issues related to pandas deprecation errors. Was required because Python 3.12 changed how pip works. Pandas resolved this, however our version limit on Pandas stopped this from being updated, meaning that PolarRoute was spitting out many warnings with Python 3.12. Some of these have been fixed, but the SettingWithCopyWarning still exists, and will become deprecated by the time Pandas 3.0 comes out. We should push the refactored route planning by then so I don't think it's worth pursuing fixing these for now.

## Fixes:  
(MeshiPhi issue #37 is most related)

# Testing
To ensure that the functionality of the PolarRoute codebase remains consistent throughout the development cycle a testing strategy has been developed, which can be viewed in the document `test/testing_strategy.md`. 
This includes a collection of test files which should be run according to which part of the codebase has been altered in a pull request. Please consult the testing strategy to determine which tests need to be run. 

- [ ] My changes have not altered any of the files listed in the testing strategy

- [x] My changes result in all required regression tests passing without the need to update test files.  
[Passing reg tests](https://github.com/antarctica/PolarRoute/files/14761697/pytest_polarroute.log)

- [ ] My changes require one or more test files to be updated for all regression tests to pass.   

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `0.4.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  