### PR TITLE
Extract routes python interface hotfix

### DIFF
--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 __description__ = "PolarRoute: Long-distance maritime polar route planning taking into account complex changing environmental conditions"
 __license__ = "MIT"
 __author__ = "Autonomous Marine Operations Planning (AMOP) Team, AI Lab, British Antarctic Survey"

--- a/polar_route/cli.py
+++ b/polar_route/cli.py
@@ -215,8 +215,11 @@ def extract_routes_cli():
     if route_file.get("type") == "FeatureCollection":
         routes = route_file["features"]
     else:
-        routes = route_file["paths"]["features"]
-
+        if "paths" in route_file.keys():
+            routes = route_file["paths"]["features"]
+        else:
+            routes = []
+            
     if output_file_strs[-1] in ["json", "geojson"]:
         geojson_outputs = extract_geojson_routes(route_file)
         # For each route extracted

--- a/polar_route/cli.py
+++ b/polar_route/cli.py
@@ -220,6 +220,8 @@ def extract_routes_cli():
         else:
             routes = []
             
+    logging.info(f"{len(routes)} routes found in mesh")
+
     if output_file_strs[-1] in ["json", "geojson"]:
         geojson_outputs = extract_geojson_routes(route_file)
         # For each route extracted

--- a/polar_route/cli.py
+++ b/polar_route/cli.py
@@ -7,7 +7,7 @@ import geopandas as gpd
 from meshiphi.mesh_generation.mesh_builder import MeshBuilder
 
 from polar_route import __version__ as version
-from polar_route.utils import setup_logging, timed_call, convert_decimal_days, to_chart_track_csv
+from polar_route.utils import setup_logging, timed_call, convert_decimal_days, to_chart_track_csv, extract_geojson_routes
 from polar_route.vessel_performance.vessel_performance_modeller import VesselPerformanceModeller
 from polar_route.route_planner import RoutePlanner
 from polar_route.route_calc import route_calc
@@ -218,15 +218,15 @@ def extract_routes_cli():
         routes = route_file["paths"]["features"]
 
     if output_file_strs[-1] in ["json", "geojson"]:
-        logging.info("Extracting routes in geojson format")
-        for route in routes:
-            geojson_wrapper = {"type": "FeatureCollection",
-                               "features": []}
+        geojson_outputs = extract_geojson_routes(args.mesh)
+        # For each route extracted
+        for geojson_output in geojson_outputs:
+            route = geojson_output['features'][0]
+            # Generate filename from route
             from_wp = route["properties"]["from"].replace(" ", "_")
             to_wp = route["properties"]["to"].replace(" ", "_")
-            geojson_output = geojson_wrapper
-            geojson_output["features"].append(route)
             route_output_str = '.'.join(output_file_strs[:-1]) + "_" + from_wp + to_wp + "." + output_file_strs[-1]
+            
             logging.info(f"Saving route to {route_output_str}")
             with open(route_output_str, "w") as f:
                 json.dump(geojson_output, f, indent=4)

--- a/polar_route/cli.py
+++ b/polar_route/cli.py
@@ -218,7 +218,7 @@ def extract_routes_cli():
         routes = route_file["paths"]["features"]
 
     if output_file_strs[-1] in ["json", "geojson"]:
-        geojson_outputs = extract_geojson_routes(args.mesh)
+        geojson_outputs = extract_geojson_routes(route_file)
         # For each route extracted
         for geojson_output in geojson_outputs:
             route = geojson_output['features'][0]

--- a/polar_route/utils.py
+++ b/polar_route/utils.py
@@ -486,7 +486,5 @@ def extract_geojson_routes(mesh):
         
         geojson_routes.append(geojson_route)
 
-    logging.info(f"{len(geojson_routes)} routes found in mesh")
-
     # Return list of individual geojson routes
     return geojson_routes

--- a/polar_route/utils.py
+++ b/polar_route/utils.py
@@ -471,7 +471,10 @@ def extract_geojson_routes(mesh):
     logging.info("Extracting routes in geojson format")
     
     # Extract the computed routes from the mesh
-    routes = mesh["paths"]["features"]
+    if "paths" in mesh.keys():
+        routes = mesh["paths"]["features"]
+    else:
+        routes = []
 
     # Reformat every route to geojson format and append to list
     geojson_routes = []

--- a/polar_route/utils.py
+++ b/polar_route/utils.py
@@ -455,10 +455,33 @@ def to_chart_track_csv(route):
 
 
 def extract_geojson_routes(mesh):
-    """
+    """_summary_
+
     Extract routes in a precomputed mesh in GEOJSON format
 
     Args:
-        mesh (_type_): _description_
+        mesh (dict): Precomputed mesh JSON with routes embedded
+        
+    Returns:
+        list: 
+            List of all routes found in mesh. If no routes found, returns 
+            empty list
     """
-    pass
+    
+    logging.info("Extracting routes in geojson format")
+    
+    # Check if input is just a route file or if the routes are nested within a mesh
+    if mesh.get("type") == "FeatureCollection":
+        routes = mesh["features"]
+    else:
+        routes = mesh["paths"]["features"]
+
+    geojson_routes = []
+
+    for route in routes:
+        geojson_route = {"type": "FeatureCollection",
+                            "features": [route]}
+        
+        geojson_routes.append(geojson_route)
+
+    return geojson_routes

--- a/polar_route/utils.py
+++ b/polar_route/utils.py
@@ -455,8 +455,8 @@ def to_chart_track_csv(route):
 
 
 def extract_geojson_routes(mesh):
-    """_summary_
-
+    """
+    
     Extract routes in a precomputed mesh in GEOJSON format
 
     Args:
@@ -470,18 +470,20 @@ def extract_geojson_routes(mesh):
     
     logging.info("Extracting routes in geojson format")
     
-    # Check if input is just a route file or if the routes are nested within a mesh
-    if mesh.get("type") == "FeatureCollection":
-        routes = mesh["features"]
-    else:
-        routes = mesh["paths"]["features"]
+    # Extract the computed routes from the mesh
+    routes = mesh["paths"]["features"]
 
+    # Reformat every route to geojson format and append to list
     geojson_routes = []
-
     for route in routes:
+        # Using FeatureCollection to keep consistent formatting with 
+        # multi-route geojsons
         geojson_route = {"type": "FeatureCollection",
                             "features": [route]}
         
         geojson_routes.append(geojson_route)
 
+    logging.info(f"{len(geojson_routes)} routes found in mesh")
+
+    # Return list of individual geojson routes
     return geojson_routes

--- a/polar_route/utils.py
+++ b/polar_route/utils.py
@@ -282,6 +282,7 @@ def setup_logging(func,
         return parsed_args
     return wrapper
 
+
 def _json_str(input):
     if type(input) is dict:
         output = input
@@ -292,6 +293,8 @@ def _json_str(input):
         except:
             raise ValueError("Unable to load '{}', please check path name".format(input))
     return output
+
+
 def case_from_angle( start,end):
         """
             Determine the direction of travel between two points in the same cell and return the associated case
@@ -328,6 +331,7 @@ def case_from_angle( start,end):
 
         return case
 
+
 def unit_time(val , unit):
         '''
             Applying Unit time for a specific input type
@@ -341,6 +345,7 @@ def unit_time(val , unit):
         elif unit == 's':
             return val
         
+
 def unit_speed(val , unit):
         '''
             Applying unit speed for an input type.
@@ -360,6 +365,7 @@ def unit_speed(val , unit):
             return val
         else:
             return None
+
 
 def gpx_route_import(f_name):
     """
@@ -384,6 +390,7 @@ def gpx_route_import(f_name):
     geojson['features'][0]['properties']['to'] = gdf_p['name'].iloc[-1]
 
     return geojson
+
 
 def to_chart_track_csv(route):
     """
@@ -447,3 +454,11 @@ def to_chart_track_csv(route):
     return csv_str
 
 
+def extract_geojson_routes(mesh):
+    """
+    Extract routes in a precomputed mesh in GEOJSON format
+
+    Args:
+        mesh (_type_): _description_
+    """
+    pass


### PR DESCRIPTION
# PolarRoute Pull Request Template

Date: 2024-08-14
Version Number: 0.5.2   
 
## Description of change
Moves the extraction of routes into geojson format from `cli.py` to `utils.py` in order to make it accessible from a python interface rather that just through the CLI. Feature requested by @davidwilby 

## Fixes #288 

# Testing
To ensure that the functionality of the PolarRoute codebase remains consistent throughout the development cycle a testing strategy has been developed, which can be viewed in the document `test/testing_strategy.md`. 
This includes a collection of test files which should be run according to which part of the codebase has been altered in a pull request. Please consult the testing strategy to determine which tests need to be run. 

- [x] My changes have not altered any of the files listed in the testing strategy
Passing reg tests: [reg_test.txt](https://github.com/user-attachments/files/16612196/reg_test.txt)

- [ ] My changes result in all required regression tests passing without the need to update test files.  
  
- [ ] My changes require one or more test files to be updated for all regression tests to pass.   

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `0.5.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
