### PR TITLE
Fix Indexing Bug for Fuel Values

### DIFF
--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 __description__ = "PolarRoute: Long-distance maritime polar route planning taking into account complex changing environmental conditions"
 __license__ = "MIT"
 __author__ = "Autonomous Marine Operations Planning (AMOP) Team, AI Lab, British Antarctic Survey"

--- a/polar_route/route_planner/route.py
+++ b/polar_route/route_planner/route.py
@@ -154,7 +154,7 @@ class Route:
                 cp (Waypoint): the crossing point that the route enters or leaves the cell by
                 indx (int): the index of the segment along the route
         """
-
+        direction = [1, 2, 3, 4, -1, -2, -3, -4]
         logging.debug(f"WP_correction >> wp >> {wp.to_point()}")
         logging.debug(f"WP_correction >> cp >> {cp.to_point()}")
         m_long = 111.321*1000
@@ -180,11 +180,11 @@ class Route:
         self.segments[indx].set_travel_time(traveltime)
         self.segments[indx].set_distance(distance)
         if 'fuel' in self.conf['path_variables']:
-            self.segments[indx].set_fuel(cellbox.agg_data['fuel'][case] * traveltime)
-            logging.debug(f"WP_correction >> fuel >> {cellbox.agg_data['fuel'][case] * traveltime}")
+            self.segments[indx].set_fuel(cellbox.agg_data['fuel'][direction.index(case)] * traveltime)
+            logging.debug(f"WP_correction >> fuel >> {cellbox.agg_data['fuel'][direction.index(case)] * traveltime}")
         if 'battery' in self.conf['path_variables']:
-            self.segments[indx].set_fuel(cellbox.agg_data['battery'][case] * traveltime)
-            logging.debug(f"WP_correction >> battery >> {cellbox.agg_data['battery'][case] * traveltime}")
+            self.segments[indx].set_fuel(cellbox.agg_data['battery'][direction.index(case)] * traveltime)
+            logging.debug(f"WP_correction >> battery >> {cellbox.agg_data['battery'][direction.index(case)] * traveltime}")
 
     def get_points(self):
         """

--- a/polar_route/route_planner/route.py
+++ b/polar_route/route_planner/route.py
@@ -28,6 +28,7 @@ class Route:
         self.to_wp = _to
         self.cases = []
         self.conf = conf
+        self.source_waypoint = None
     
     def get_distance(self):
         """

--- a/polar_route/route_planner/route_planner.py
+++ b/polar_route/route_planner/route_planner.py
@@ -485,12 +485,11 @@ class RoutePlanner:
             for case, neighbours in neighbour_map.items():
                 if len(neighbours) != 0:
                   for neighbour in neighbours:
-                     if not source_wp.is_visited(neighbour): # skip visited nodes to avoid cycles
-                        edges = self._neighbour_cost(_id, str(neighbour), int(case))
-                        edges_cost = sum(segment.get_variable(self.config['objective_function']) for segment in edges)
-                        new_cost = source_wp.get_obj( _id, self.config['objective_function']) + edges_cost
-                        if new_cost < source_wp.get_obj(str(neighbour), self.config['objective_function']):
-                            source_wp.update_routing_table(str(neighbour), RoutingInfo(_id, edges))
+                    edges = self._neighbour_cost(_id, str(neighbour), int(case))
+                    edges_cost = sum(segment.get_variable(self.config['objective_function']) for segment in edges)
+                    new_cost = source_wp.get_obj( _id, self.config['objective_function']) + edges_cost
+                    if new_cost < source_wp.get_obj(str(neighbour), self.config['objective_function']):
+                        source_wp.update_routing_table(str(neighbour), RoutingInfo(_id, edges))
                 
         # Updating Dijkstra as long as all the waypoints are not visited or for full graph
         for end_wp in end_wps:
@@ -747,8 +746,6 @@ class RoutePlanner:
 
         """
         dijkstra_graph_dict = dict()
-        path_variables = route.conf['path_variables']
-        idx = 0
         for cell in cellboxes:
             if cell['inaccessible']:
                 continue
@@ -769,19 +766,10 @@ class RoutePlanner:
                 if leg_id in self.neighbour_legs:
                     neighbour_travel_legs.append(self.neighbour_legs[leg_id][0])
                     neighbour_crossing_points.append(self.neighbour_legs[leg_id][1])
-                else:
-                    cost_func = self.cost_func(str(cell_id), str(neighbour), self.cellboxes_lookup, case=cases[i],
-                                               unit_shipspeed='km/hr', time_unit=self.config['time_unit'])
-                    traveltime, crossing_points, cell_points, case = cost_func.value()
-                    neighbour_travel_legs.append(traveltime)
-                    neighbour_crossing_points.append(crossing_points)
             dijkstra_graph_dict[cell_id]['neighbourTravelLegs'] = np.array(neighbour_travel_legs)
             dijkstra_graph_dict[cell_id]['neighbourCrossingPoints'] = np.array(neighbour_crossing_points)
-            dijkstra_graph_dict[cell_id]['pathPoints'] = route.get_points()
-            for variable in path_variables:
-                dijkstra_graph_dict[cell_id][f'path_{variable}'] = np.array(route.accumulate_metric(variable))
-            dijkstra_graph_dict[cell_id]['pathIndex'] = route.source_waypoint.get_routing_info(str(cell_id)).get_path_nodes()
-            idx += 1
+            # TODO: add option to calculate pathIndex
+            # dijkstra_graph_dict[cell_id]['pathIndex'] = route.source_waypoint.get_routing_info(str(cell_id)).get_path_nodes()
 
         return dijkstra_graph_dict
 

--- a/polar_route/route_planner/route_planner.py
+++ b/polar_route/route_planner/route_planner.py
@@ -395,6 +395,7 @@ class RoutePlanner:
                 if s_wp.get_cellbox_indx() == e_wp_indx:
                    # Route should be a straight line within the same cellbox
                    route = Route([Segment(s_wp, e_wp)], s_wp.get_name(), e_wp.get_name(), self.config)
+                   route.source_waypoint = s_wp
                 else:
                     while s_wp.get_cellbox_indx() != e_wp_indx:
                         # logging.debug(">>> s_wp_indx >>>", s_wp)
@@ -423,6 +424,7 @@ class RoutePlanner:
                    
                     route_segments = list(itertools.chain.from_iterable(route_segments))
                     route = Route(route_segments, s_wp.get_name(), e_wp.get_name(), self.config)
+                    route.source_waypoint = s_wp
                     route.set_cases(cases)
                     for s in route_segments:
                         logging.debug(f">>>|S|>>>> {s.to_str()}")
@@ -778,12 +780,7 @@ class RoutePlanner:
             dijkstra_graph_dict[cell_id]['pathPoints'] = route.get_points()
             for variable in path_variables:
                 dijkstra_graph_dict[cell_id][f'path_{variable}'] = np.array(route.accumulate_metric(variable))
-            if idx == 0:
-                dijkstra_graph_dict[cell_id]['pathIndex'] = np.array([0])
-                prev_cell = cell_id
-            else:
-                dijkstra_graph_dict[cell_id]['pathIndex'] = np.append(dijkstra_graph_dict[prev_cell]['pathIndex'], idx)
-                prev_cell = cell_id
+            dijkstra_graph_dict[cell_id]['pathIndex'] = route.source_waypoint.get_routing_info(str(cell_id)).get_path_nodes()
             idx += 1
 
         return dijkstra_graph_dict

--- a/polar_route/route_planner/route_planner.py
+++ b/polar_route/route_planner/route_planner.py
@@ -731,14 +731,15 @@ class RoutePlanner:
         self.routes_smoothed = geojson
         return self.routes_smoothed
 
-    def initialise_dijkstra_graph(self, cellboxes, neighbour_graph, route):
+    def initialise_dijkstra_graph(self, cellboxes, neighbour_graph, route, path_index=False):
         """
             Initialising dijkstra graph information in a standard form used for the smoothing
 
             Args:
-                cellboxes (list): list of cells with environmental and vessel performance info
-                neighbour_graph (dict): neighbour graph for the mesh
+                cellboxes (list): List of cells with environmental and vessel performance info
+                neighbour_graph (dict): Neighbour graph for the mesh
                 route (Route): Route object for the route to be smoothed
+                path_index (bool): Option to generate the pathIndex array that can be used to generate new dijkstra routes
 
             Outputs:
                 dijkstra_graph_dict (dict) - Dictionary comprising dijkstra graph with keys based on cellbox id.
@@ -768,8 +769,8 @@ class RoutePlanner:
                     neighbour_crossing_points.append(self.neighbour_legs[leg_id][1])
             dijkstra_graph_dict[cell_id]['neighbourTravelLegs'] = np.array(neighbour_travel_legs)
             dijkstra_graph_dict[cell_id]['neighbourCrossingPoints'] = np.array(neighbour_crossing_points)
-            # TODO: add option to calculate pathIndex
-            # dijkstra_graph_dict[cell_id]['pathIndex'] = route.source_waypoint.get_routing_info(str(cell_id)).get_path_nodes()
+            if path_index:
+                dijkstra_graph_dict[cell_id]['pathIndex'] = route.source_waypoint.get_path_nodes(str(cell_id))
 
         return dijkstra_graph_dict
 

--- a/polar_route/route_planner/route_planner.py
+++ b/polar_route/route_planner/route_planner.py
@@ -526,7 +526,7 @@ class RoutePlanner:
         # Updating the Dijkstra graph with the new information
         traveltime, crossing_points, cell_points, case = cost_func.value()
         # Save travel time and crossing point values for use in smoothing
-        self.neighbour_legs[node_id+neighbour_id] = (traveltime, crossing_points)
+        self.neighbour_legs[node_id+"to"+neighbour_id] = (traveltime, crossing_points)
 
         # Create segments and set their travel time based on the returned 3 points and the remaining obj accordingly (travel_time * node speed/fuel)
         s1 = Segment(Waypoint.load_from_cellbox(self.cellboxes_lookup[node_id]), Waypoint(crossing_points[1],
@@ -763,7 +763,7 @@ class RoutePlanner:
             neighbour_travel_legs = []
             neighbour_crossing_points = []
             for i, neighbour in enumerate(neighbour_index):
-                leg_id = str(cell_id) + str(neighbour)
+                leg_id = str(cell_id) + "to" + str(neighbour)
                 if leg_id in self.neighbour_legs:
                     neighbour_travel_legs.append(self.neighbour_legs[leg_id][0])
                     neighbour_crossing_points.append(self.neighbour_legs[leg_id][1])

--- a/polar_route/route_planner/routing_info.py
+++ b/polar_route/route_planner/routing_info.py
@@ -22,7 +22,21 @@ class RoutingInfo:
             Returns the associated path
         """
         return self.path
-    
+
+    def get_path_nodes(self):
+        """
+            Gets a list of nodes visited along the associated path
+        """
+        points = []
+
+        if len(self.path) > 0:
+            points = [seg.get_end_wp().get_cellbox_indx() for seg in self.path]
+            print(len(points))
+            points.insert(0, self.path[0].get_start_wp().get_cellbox_indx())
+            print(len(points))
+
+        return points
+
     def get_node_index(self):
         """
             Returns the associated node index

--- a/polar_route/route_planner/routing_info.py
+++ b/polar_route/route_planner/routing_info.py
@@ -31,9 +31,7 @@ class RoutingInfo:
 
         if len(self.path) > 0:
             points = [seg.get_end_wp().get_cellbox_indx() for seg in self.path]
-            print(len(points))
             points.insert(0, self.path[0].get_start_wp().get_cellbox_indx())
-            print(len(points))
 
         return points
 

--- a/polar_route/route_planner/routing_info.py
+++ b/polar_route/route_planner/routing_info.py
@@ -31,8 +31,7 @@ class RoutingInfo:
 
         if len(self.path) > 0:
             points = [seg.get_end_wp().get_cellbox_indx() for seg in self.path]
-            points.insert(0, self.path[0].get_start_wp().get_cellbox_indx())
-
+            
         return points
 
     def get_node_index(self):

--- a/polar_route/route_planner/source_waypoint.py
+++ b/polar_route/route_planner/source_waypoint.py
@@ -72,6 +72,25 @@ class SourceWaypoint(Waypoint):
             self.routing_table[_id] = RoutingInfo(-1, None) # indicating inaccessible node and returns infinity obj
         return self.routing_table[_id]
 
+    def get_path_nodes(self, _id):
+        """
+        Gets all nodes on the path from the source waypoint to the node at _id
+        """
+        if _id not in self.routing_table.keys():
+            return []
+        else:
+            node_id = _id
+            path_index = list()
+            while node_id != self.cellbox_indx:
+                node_indices = self.routing_table[node_id].get_path_nodes()
+                path_index.insert(0, node_indices[1])
+                node_id = node_indices[0]
+
+            path_index.insert(0, self.cellbox_indx)
+
+
+            return path_index
+
     def log_routing_table(self):
         logging.debug(f'Routing table of {self.cellbox_indx} source waypoint:')
         for x in self.routing_table.keys():


### PR DESCRIPTION
# PolarRoute Pull Request 

Date: 02/09/24 
Version Number: 0.6.3
 
## Description of change
After playing around with one of the simple test examples and looking again at the `waypoint_correction` method of the `Route` class I found the source of the fuel bug that's been causing tests to fail. Turned out be an annoyingly simple indexing issue: the actual case value was being used to get the fuel values for this method instead of the corresponding index. All tests now pass, see the attached log.

I have now also added a change that fixes the bug identified in #291.

Further changes were made to ensure all relevant elements of the dijkstra graph match between v0.6 and v0.5.

## Fixes #291 
The regression tests


# Testing

- [x] My changes result in all required regression tests passing without the need to update test files.  
  
Test dump: 
[route_tests_050924.txt](https://github.com/user-attachments/files/16887454/route_tests_050924.txt)


Files changed:
```
polar_route/__init__.py
polar_route/route_planner/route.py
polar_route/route_planner/route_planner.py
polar_route/route_planner/routing_info.py
polar_route/route_planner/source_waypoint.py
```

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `0.6.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
