### PR TITLE
Ignore waypoints outside mesh instead of raising error

### DIFF
--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 __description__ = "PolarRoute: Long-distance maritime polar route planning taking into account complex changing environmental conditions"
 __license__ = "MIT"
 __author__ = "Autonomous Marine Operations Planning (AMOP) Team, AI Lab, British Antarctic Survey"


### PR DESCRIPTION
# PolarRoute Pull Request 

Date: 17/10/24
Version Number: 1.1.0   
 
## Description of change
Remove assert statement to allow the route planner to run when some waypoints are outside the provided mesh. I also tidied up a few other waypoint related things for style etc.

## Fixes #304

# Testing

- [x] My changes result in all required regression tests passing without the need to update test files.  

Test results: [route_tests_171024.txt](https://github.com/user-attachments/files/17410967/route_tests_171024.txt)


Files changed:
```
polar_route/__init__.py
polar_route/route_planner/route_planner.py
```  

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `1.1.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
