### PR TITLE
Add option for custom vessel performance classes

### DIFF
--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __description__ = "PolarRoute: Long-distance maritime polar route planning taking into account complex changing environmental conditions"
 __license__ = "MIT"
 __author__ = "Autonomous Marine Operations Planning (AMOP) Team, AI Lab, British Antarctic Survey"

--- a/polar_route/vessel_performance/vessel_performance_modeller.py
+++ b/polar_route/vessel_performance/vessel_performance_modeller.py
@@ -13,12 +13,13 @@ class VesselPerformanceModeller:
         Takes both an environmental mesh and vessel config as input in json format and modifies the input mesh to
         include vessel specifics.
     """
-    def __init__(self, env_mesh_json, vessel_config):
+    def __init__(self, env_mesh_json, vessel_config, custom_vessel=None):
         """
 
         Args:
             env_mesh_json (dict): a dictionary loaded from an environmental mesh json file
             vessel_config (dict): a dictionary loaded from a vessel config json file
+            custom_vessel (class): a custom vessel object that specifies a set of performance and accessibility models
         """
         logging.info("Initialising Vessel Performance Modeller")
         validate_vessel_config(vessel_config)
@@ -30,7 +31,11 @@ class VesselPerformanceModeller:
         if 'neighbour_splitting' not in self.config:
             self.config['neighbour_splitting'] = True
 
-        self.vessel = VesselFactory.get_vessel(vessel_config)
+        if custom_vessel is not None:
+            logging.info(f"Loading custom vessel class: {type(custom_vessel).__name__}")
+            self.vessel = custom_vessel(vessel_config)
+        else:
+            self.vessel = VesselFactory.get_vessel(vessel_config)
 
         self.filter_nans()
 

--- a/polar_route/vessel_performance/vessels/abstract_alr.py
+++ b/polar_route/vessel_performance/vessels/abstract_alr.py
@@ -14,7 +14,7 @@ class AbstractALR(AbstractVessel):
                 params (dict): vessel parameters from the vessel config file
         """
         self.vessel_params = params
-        logging.info(f"Initialising a vessel object of type: {self.vessel_params['vessel_type']}")
+        logging.info(f"Initialising a vessel object of type: {self.__class__.__name__}")
         self.max_speed      = self.vessel_params['max_speed']
         self.speed_unit     = self.vessel_params['unit']
         self.max_elevation  = -1 * self.vessel_params['min_depth']
@@ -30,7 +30,7 @@ class AbstractALR(AbstractVessel):
                     cellbox (AggregatedCellBox): input cell from environmental mesh
         """
         logging.debug(
-            f"Modelling performance in cell {cellbox.id} for a vessel of type: {self.vessel_params['vessel_type']}")
+            f"Modelling performance in cell {cellbox.id} for a vessel of type: {self.__class__.__name__}")
         perf_cellbox = self.model_speed(cellbox)
         perf_cellbox = self.model_battery(perf_cellbox)
 
@@ -47,8 +47,7 @@ class AbstractALR(AbstractVessel):
             Returns:
                 access_values (dict): boolean values for the modelled accessibility criteria
         """
-        logging.debug(f"Modelling accessibility in cell {cellbox.id} for a vessel of type: "
-                      f"{self.vessel_params['vessel_type']}")
+        logging.debug(f"Modelling accessibility in cell {cellbox.id} for a vessel of type: {self.__class__.__name__}")
         access_values = dict()
 
         # Exclude cells due to land or ice
@@ -97,8 +96,9 @@ class AbstractALR(AbstractVessel):
             shallow = False
         else:
             condition_shallow1 = 0.0 > cellbox.agg_data['elevation'] > self.max_elevation
+            shallow = any([condition_shallow1])
 
-        return any([condition_shallow1])
+        return shallow
 
 
     def extreme_ice(self, cellbox):

--- a/polar_route/vessel_performance/vessels/abstract_glider.py
+++ b/polar_route/vessel_performance/vessels/abstract_glider.py
@@ -14,7 +14,7 @@ class AbstractGlider(AbstractVessel):
                 params (dict): vessel parameters from the vessel config file
         """
         self.vessel_params = params
-        logging.info(f"Initialising a vessel object of type: {self.vessel_params['vessel_type']}")
+        logging.info(f"Initialising a vessel object of type: {self.__class__.__name__}")
         self.max_speed = self.vessel_params['max_speed']
         self.speed_unit = self.vessel_params['unit']
         self.max_elevation = -1 * self.vessel_params['min_depth']
@@ -30,7 +30,7 @@ class AbstractGlider(AbstractVessel):
                     cellbox (AggregatedCellBox): input cell from environmental mesh
         """
         logging.debug(
-            f"Modelling performance in cell {cellbox.id} for a vessel of type: {self.vessel_params['vessel_type']}")
+            f"Modelling performance in cell {cellbox.id} for a vessel of type: {self.__class__.__name__}")
         perf_cellbox = self.model_speed(cellbox)
         perf_cellbox = self.model_battery(perf_cellbox)
 
@@ -47,8 +47,7 @@ class AbstractGlider(AbstractVessel):
             Returns:
                 access_values (dict): boolean values for the modelled accessibility criteria
         """
-        logging.debug(f"Modelling accessibility in cell {cellbox.id} for a vessel of type: "
-                      f"{self.vessel_params['vessel_type']}")
+        logging.debug(f"Modelling accessibility in cell {cellbox.id} for a vessel of type: {self.__class__.__name__}")
         access_values = dict()
 
         # Exclude cells due to land or ice

--- a/polar_route/vessel_performance/vessels/abstract_plane.py
+++ b/polar_route/vessel_performance/vessels/abstract_plane.py
@@ -14,7 +14,7 @@ class AbstractPlane(AbstractVessel):
                 params (dict): vessel parameters from the vessel config file
         """
         self.vessel_params = params
-        logging.info(f"Initialising a vessel object of type: {self.vessel_params['vessel_type']}")
+        logging.info(f"Initialising a vessel object of type: {self.__class__.__name__}")
         self.max_speed      = self.vessel_params['max_speed']
         self.speed_unit     = self.vessel_params['unit']
         self.max_elevation  = self.vessel_params['max_elevation']
@@ -29,8 +29,7 @@ class AbstractPlane(AbstractVessel):
             Args:
                     cellbox (AggregatedCellBox): input cell from environmental mesh
         """
-        logging.debug(
-            f"Modelling performance in cell {cellbox.id} for a vessel of type: {self.vessel_params['vessel_type']}")
+        logging.debug("Modelling performance in cell {cellbox.id} for a vessel of type: {self.__class__.__name__}")
         perf_cellbox = self.model_speed(cellbox)
         perf_cellbox = self.model_fuel(perf_cellbox)
 
@@ -47,8 +46,7 @@ class AbstractPlane(AbstractVessel):
             Returns:
                 access_values (dict): boolean values for the modelled accessibility criteria
         """
-        logging.debug(f"Modelling accessibility in cell {cellbox.id} for a vessel of type: "
-                      f"{self.vessel_params['vessel_type']}")
+        logging.debug(f"Modelling accessibility in cell {cellbox.id} for a vessel of type: {self.__class__.__name__}")
         access_values = dict()
 
         # Exclude cells due to land or ice
@@ -89,9 +87,14 @@ class AbstractPlane(AbstractVessel):
             Args:
                 cellbox (AggregatedCellBox): input cell from environmental mesh
             Returns:
-                elevation_max (bool): boolean that is True if the cell is too elevation_max for a glider
+                elevation_max (bool): boolean that is True if the elevation in a cell is too high for a plane
         """
-        elevation_max = False
+        if 'elevation' not in cellbox.agg_data:
+            logging.warning(f"No elevation data in cell {cellbox.id}, cannot determine if it is too high")
+            elevation_max = False
+        else:
+            elevation_max = cellbox.agg_data['elevation'] > self.max_elevation
+
         return elevation_max
 
     @abstractmethod

--- a/polar_route/vessel_performance/vessels/abstract_ship.py
+++ b/polar_route/vessel_performance/vessels/abstract_ship.py
@@ -13,7 +13,7 @@ class AbstractShip(AbstractVessel):
                 params (dict): vessel parameters from the vessel config file
         """
         self.vessel_params = params
-        logging.info(f"Initialising a vessel object of type: {self.vessel_params['vessel_type']}")
+        logging.info(f"Initialising a vessel object of type: {self.__class__.__name__}")
 
         self.max_speed = self.vessel_params['max_speed']
         self.speed_unit = self.vessel_params['unit']
@@ -32,7 +32,7 @@ class AbstractShip(AbstractVessel):
             Returns:
                 performance_values (dict): the value of the modelled performance characteristics for the ship
         """
-        logging.debug(f"Modelling performance in cell {cellbox.id} for a vessel of type: {self.vessel_params['vessel_type']}")
+        logging.debug(f"Modelling performance in cell {cellbox.id} for a vessel of type: {self.__class__.__name__}")
         # Check if the speed is defined in the input cellbox
         if 'speed' not in cellbox.agg_data:
             logging.debug(f'No speed in cell, assigning default value of {self.max_speed} '
@@ -56,8 +56,7 @@ class AbstractShip(AbstractVessel):
             Returns:
                 access_values (dict): boolean values for the modelled accessibility criteria
         """
-        logging.debug(f"Modelling accessibility in cell {cellbox.id} for a vessel of type: "
-                      f"{self.vessel_params['vessel_type']}")
+        logging.debug(f"Modelling accessibility in cell {cellbox.id} for a vessel of type: {self.__class__.__name__}")
         access_values = dict()
 
         # Make land and extreme ice cells inaccessible

--- a/polar_route/vessel_performance/vessels/abstract_uav.py
+++ b/polar_route/vessel_performance/vessels/abstract_uav.py
@@ -14,7 +14,7 @@ class AbstractUAV(AbstractVessel):
                 params (dict): vessel parameters from the vessel config file
         """
         self.vessel_params = params
-        logging.info(f"Initialising a vessel object of type: {self.vessel_params['vessel_type']}")
+        logging.info(f"Initialising a vessel object of type: {self.__class__.__name__}")
         self.max_speed      = self.vessel_params['max_speed']
         self.speed_unit     = self.vessel_params['unit']
         self.max_elevation  = self.vessel_params['max_elevation']
@@ -30,7 +30,7 @@ class AbstractUAV(AbstractVessel):
                     cellbox (AggregatedCellBox): input cell from environmental mesh
         """
         logging.debug(
-            f"Modelling performance in cell {cellbox.id} for a vessel of type: {self.vessel_params['vessel_type']}")
+            f"Modelling performance in cell {cellbox.id} for a vessel of type: {self.__class__.__name__}")
         perf_cellbox = self.model_speed(cellbox)
         perf_cellbox = self.model_battery(perf_cellbox)
 
@@ -47,8 +47,7 @@ class AbstractUAV(AbstractVessel):
             Returns:
                 access_values (dict): boolean values for the modelled accessibility criteria
         """
-        logging.debug(f"Modelling accessibility in cell {cellbox.id} for a vessel of type: "
-                      f"{self.vessel_params['vessel_type']}")
+        logging.debug(f"Modelling accessibility in cell {cellbox.id} for a vessel of type: {self.__class__.__name__}")
         access_values = dict()
 
         # Exclude cells due to land or ice

--- a/polar_route/vessel_performance/vessels/example_ship.py
+++ b/polar_route/vessel_performance/vessels/example_ship.py
@@ -29,7 +29,7 @@ class ExampleShip(AbstractShip):
                 cellbox (AggregatedCellBox): updated cell with speed values
         """
 
-        logging.debug(f"Calculating new speed for cellbox {cellbox.id} based on SDA resistance models")
+        logging.debug(f"Calculating new speed for cellbox {cellbox.id} based on resistance modelling")
         speed = cellbox.agg_data['speed']
         ice_resistance = None
 


### PR DESCRIPTION
# PolarRoute Pull Request

Date: 18/10/24  
Version Number: 1.1.1
 
## Description of change
Adds the option to specify a custom vessel class when initialising the vessel performance modeller (bypassing the vessel factory) to make prototyping new models simpler. Also fixes a couple of small bugs with existing vessel models (alr/plane).

## Fixes #261

# Testing

- [x] My changes result in all required regression tests passing without the need to update test files.  
  
Test results: [vessel_tests_181024.txt](https://github.com/user-attachments/files/17436753/vessel_tests_181024.txt)


Files changed:
```
polar_route/__init__.py
polar_route/vessel_performance/vessel_performance_modeller.py
polar_route/vessel_performance/vessels/abstract_alr.py
polar_route/vessel_performance/vessels/abstract_glider.py
polar_route/vessel_performance/vessels/abstract_plane.py
polar_route/vessel_performance/vessels/abstract_ship.py
polar_route/vessel_performance/vessels/abstract_uav.py
polar_route/vessel_performance/vessels/example_ship.py
```

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `1.1.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
