### PR TITLE
Bug Fixing - Path Smoothing failures

### DIFF
--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 __description__ = "PolarRoute: Long-distance maritime polar route planning taking into account complex changing environmental conditions"
 __license__ = "MIT"
 __author__ = "Autonomous Marine Operations Planning (AMOP) Team, AI Lab, British Antarctic Survey"

--- a/polar_route/route_planner/crossing_smoothing.py
+++ b/polar_route/route_planner/crossing_smoothing.py
@@ -1083,14 +1083,10 @@ class Smoothing:
                 True if this v-additional case has been seen before, or false if not
 
         """
-        try:
-            edge_a_start_index = edge_a.start['id']
-            edge_b_start_index = edge_b.start['id']
-            edge_a_end_index   = edge_a.end['id']
-            edge_b_end_index   = edge_b.end['id']
-        except:
-            return True
-
+        edge_a_start_index = edge_a.start['id']
+        edge_b_start_index = edge_b.start['id']
+        edge_a_end_index   = edge_a.end['id']
+        edge_b_end_index   = edge_b.end['id']
 
         current_v = [edge_a_start_index, edge_a_end_index,
                      edge_b_start_index, edge_b_end_index,

--- a/polar_route/route_planner/crossing_smoothing.py
+++ b/polar_route/route_planner/crossing_smoothing.py
@@ -1083,10 +1083,14 @@ class Smoothing:
                 True if this v-additional case has been seen before, or false if not
 
         """
-        edge_a_start_index = edge_a.start['id']
-        edge_b_start_index = edge_b.start['id']
-        edge_a_end_index   = edge_a.end['id']
-        edge_b_end_index   = edge_b.end['id']
+        try:
+            edge_a_start_index = edge_a.start['id']
+            edge_b_start_index = edge_b.start['id']
+            edge_a_end_index   = edge_a.end['id']
+            edge_b_end_index   = edge_b.end['id']
+        except:
+            return True
+
 
         current_v = [edge_a_start_index, edge_a_end_index,
                      edge_b_start_index, edge_b_end_index,
@@ -1365,6 +1369,7 @@ class Smoothing:
                             ii += 1
                             firstpoint = midpoint_prime
                         else:
+                            print(ap.start['id'],target['id'],ap.end['id'],case_a,case_b)
                             edge_a = FindEdge(ap.start, target, case_a)
                             edge_b = FindEdge(target, ap.end, case_b)
 

--- a/polar_route/route_planner/crossing_smoothing.py
+++ b/polar_route/route_planner/crossing_smoothing.py
@@ -1369,7 +1369,6 @@ class Smoothing:
                             ii += 1
                             firstpoint = midpoint_prime
                         else:
-                            print(ap.start['id'],target['id'],ap.end['id'],case_a,case_b)
                             edge_a = FindEdge(ap.start, target, case_a)
                             edge_b = FindEdge(target, ap.end, case_b)
 

--- a/polar_route/route_planner/route_planner.py
+++ b/polar_route/route_planner/route_planner.py
@@ -241,6 +241,10 @@ class RoutePlanner:
         if 'time_unit' not in self.config:
             self.config['time_unit'] = "days"
 
+        # Early Stopping not then define as false:
+        if 'early_stopping_criterion' not in self.config:
+            self.config['early_stopping_criterion'] = True
+
         # Load mesh json from file or dict
         mesh_json = json_str(mesh_file)
 
@@ -504,22 +508,28 @@ class RoutePlanner:
                     if new_cost < source_wp.get_obj(str(neighbour), self.config['objective_function']):
                         source_wp.update_routing_table(str(neighbour), RoutingInfo(_id, edges))
                 
-        # # Updating Dijkstra as long as all the end waypoints are not visited
-        # for end_wp in end_wps:
-        #     if wp.equals(end_wp):
-        #         continue
-        #     logging.info(f"Destination waypoint: {end_wp.get_name()}")
-
-        # All_run = False
-        while not wp.is_all_visited():
-            # Determine the index of the cell with the minimum objective function cost that has not yet been visited
-            min_obj_indx = find_min_objective(wp)
-            logging.debug(f"min_obj >>> {min_obj_indx}")
-            # If min_obj_indx is -1 then no route possible, and we stop search for this waypoint
-            if min_obj_indx == -1:
-                break
-            consider_neighbours(wp, min_obj_indx)
-            wp.visit(min_obj_indx)
+        
+        if self.config['early_stopping_criterion']:
+            All_run = False
+            while not All_run:
+                # Determine the index of the cell with the minimum objective function cost that has not yet been visited
+                min_obj_indx = find_min_objective(wp)
+                logging.debug(f"min_obj >>> {min_obj_indx}")
+                # If min_obj_indx is -1 then no route possible, and we stop search for this waypoint
+                if min_obj_indx == -1:
+                    break
+                consider_neighbours(wp, min_obj_indx)
+                wp.visit(min_obj_indx)
+        else:
+            while not wp.is_all_visited():
+                # Determine the index of the cell with the minimum objective function cost that has not yet been visited
+                min_obj_indx = find_min_objective(wp)
+                logging.debug(f"min_obj >>> {min_obj_indx}")
+                # If min_obj_indx is -1 then no route possible, and we stop search for this waypoint
+                if min_obj_indx == -1:
+                    break
+                consider_neighbours(wp, min_obj_indx)
+                wp.visit(min_obj_indx)
 
     def _neighbour_cost(self, node_id, neighbour_id, case):
         """

--- a/polar_route/route_planner/route_planner.py
+++ b/polar_route/route_planner/route_planner.py
@@ -309,10 +309,10 @@ class RoutePlanner:
         """
         if ('waypoint_splitting' in self.config) and (self.config['waypoint_splitting']):
             logging.info(' Splitting around waypoints !')
-            prior_cells = [cellbox.get_id() for cellbox in self.env_mesh.agg_cellboxes if cellbox.agg_data['inaccessible']]
+            prior_cells = [cellbox.get_id() for cellbox in self.env_mesh.agg_cellboxes if not cellbox.agg_data['inaccessible']]
             wps_points = [(entry['Lat'], entry['Long']) for _, entry in waypoints_df.iterrows()]
             self.env_mesh.split_points(wps_points)
-            new_cells = [cellbox.get_id() for cellbox in self.env_mesh.agg_cellboxes if cellbox.agg_data['inaccessible']]
+            new_cells = [cellbox.get_id() for cellbox in self.env_mesh.agg_cellboxes if not cellbox.agg_data['inaccessible']]
             self._required_nodes += list(set(new_cells) - set(prior_cells))
             self.env_mesh = EnvironmentMesh.load_from_json(self.env_mesh.to_json())
             self.cellboxes_lookup = {str(self.env_mesh.agg_cellboxes[i].get_id()): self.env_mesh.agg_cellboxes[i]

--- a/polar_route/route_planner/source_waypoint.py
+++ b/polar_route/route_planner/source_waypoint.py
@@ -64,6 +64,8 @@ class SourceWaypoint(Waypoint):
         Returns:
             True if all have been visited and False if not
         """
+        if len(cells) == 0:
+            return True
         for cell in cells:
             if cell not in self.visited_nodes:
                 return False

--- a/polar_route/route_planner/source_waypoint.py
+++ b/polar_route/route_planner/source_waypoint.py
@@ -55,6 +55,21 @@ class SourceWaypoint(Waypoint):
         """
         return str(indx) in self.visited_nodes
     
+
+    def is_all_cells_visited(self,cells):
+        """
+        Check if all cells have been visited
+        Args:
+            cells (list): List of cellbox id's to check against
+        Returns:
+            True if all have been visited and False if not
+        """
+        for cell in cells:
+            if cell not in self.visited_nodes:
+                return False
+        return True
+
+
     def is_all_visited(self):
         """
         Check if all associated destination waypoints have been visited


### PR DESCRIPTION
# PolarRoute Pull Request Template

Date: <!--- Include date PR was created -->   
Version Number: <!--- Include version number of PolarRoute the PR will be included in (e.g. 1.0 -> 1.1) -->   
 
## Description of change
<!--- Describe your changes in detail -->

Fixing bug raised in #303 

Fixed bug where dijkstra was called multiple times for the same graph

Fixed bug where early stopping criterion was not present in the codebase

## Fixes # (issue)
<!--- If this PR adds functionality or resolves problems associated with an issue on GitHub, please include a link to the issue -->

# Testing
To ensure that the functionality of the PolarRoute codebase remains consistent throughout the development cycle a testing strategy has been developed, which can be viewed in the document `test/testing_strategy.md`. 
This includes a collection of test files which should be run according to which part of the codebase has been altered in a pull request. Please consult the testing strategy to determine which tests need to be run. 

- [ ] My changes have not altered any of the files listed in the testing strategy

- [ ] My changes result in all required regression tests passing without the need to update test files.  
  
> *list which files have been altered and include a pytest.txt file for each of
> the tests required to be run*
>
> The files which have been changed during this PR can be listed using the command

    git diff --name-only 1.1.x

- [ ] My changes require one or more test files to be updated for all regression tests to pass.   

> *include pytest.txt file showing which tests fail.*  
> *include reasoning as to why your changes cause these tests to fail.* 
>
> Should these changes be valid, relevant test files should be updated.  
> *include pytest.txt file of test passing after test files have been updated.*

# Checklist

- [ ] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `1.1.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
