### PR TITLE
Custom exceptions

### DIFF
--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -13,6 +13,7 @@ try:
 
     from polar_route.vessel_performance.vessel_performance_modeller import VesselPerformanceModeller as VesselPerformanceModeller
     from polar_route.route_planner.route_planner import RoutePlanner as RoutePlanner
+    from polar_route.exceptions import WayPointOutOfBounds, NoRouteFound, InaccessibleWaypoint, RouteCouldNotSmooth, InvalidMesh
 
 except ModuleNotFoundError as err:
     print(f'{err}\n Is PolarRoute installed correctly?')

--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -13,7 +13,7 @@ try:
 
     from polar_route.vessel_performance.vessel_performance_modeller import VesselPerformanceModeller as VesselPerformanceModeller
     from polar_route.route_planner.route_planner import RoutePlanner as RoutePlanner
-    from polar_route.exceptions import WayPointOutOfBounds, NoRouteFound, InaccessibleWaypoint, RouteCouldNotSmooth, InvalidMesh
+    from polar_route.exceptions import WayPointOutOfBoundsError, NoRouteFoundError, InaccessibleWaypointError, RouteCouldNotSmoothError, InvalidMeshError
 
 except ModuleNotFoundError as err:
     print(f'{err}\n Is PolarRoute installed correctly?')

--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -13,7 +13,7 @@ try:
 
     from polar_route.vessel_performance.vessel_performance_modeller import VesselPerformanceModeller as VesselPerformanceModeller
     from polar_route.route_planner.route_planner import RoutePlanner as RoutePlanner
-    from polar_route.exceptions import WayPointOutOfBoundsError, NoRouteFoundError, InaccessibleWaypointError, RouteCouldNotSmoothError, InvalidMeshError
+    from polar_route.exceptions import WaypointOutOfBoundsError, NoRouteFoundError, InaccessibleWaypointError, RouteSmoothingError, InvalidMeshError
 
 except ModuleNotFoundError as err:
     print(f'{err}\n Is PolarRoute installed correctly?')

--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 __description__ = "PolarRoute: Long-distance maritime polar route planning taking into account complex changing environmental conditions"
 __license__ = "MIT"
 __author__ = "Autonomous Marine Operations Planning (AMOP) Team, AI Lab, British Antarctic Survey"

--- a/polar_route/exceptions.py
+++ b/polar_route/exceptions.py
@@ -5,13 +5,34 @@
 class WayPointOutOfBounds(Exception):
     "Raised when the waypoint is out of bounds of the mesh"
 
-    def __init__(self, message="Waypoint is out of bounds of the mesh"):
-        self.message = message
+    def __init__(self, waypoint, message="Waypoint is out of bounds of the mesh"):
+        self.message = "Waypoint at " + str(waypoint) + " is out of bounds of the mesh"
         super().__init__(self.message)
 
 class NoRouteFound(Exception):
-    "Raised when the route is not found"
+    "Raised when a route cannot be found between two waypoints"
 
     def __init__(self, message="No route found"):
+        self.message = message
+        super().__init__(self.message)
+
+class InaccessibleWaypoint(Exception):
+    "Raised when a waypoint is inaccessible"
+
+    def __init__(self, waypoint, message="Waypoint is inaccessible"):
+        self.message = "Waypoint at " + str(waypoint) + " is inaccessible"
+        super().__init__(self.message)
+
+class RouteCouldNotSmooth(Exception):
+    "Raised when a route cannot be smoothed"
+
+    def __init__(self, message="Route could not be smoothed"):
+        self.message = message
+        super().__init__(self.message)
+
+class InvalidMesh(Exception):
+    "Raised when the mesh is invalid"
+
+    def __init__(self, message="Invalid mesh"):
         self.message = message
         super().__init__(self.message)

--- a/polar_route/exceptions.py
+++ b/polar_route/exceptions.py
@@ -2,35 +2,35 @@
     This module contains the custom exceptions for the polar_route package.
 """
 
-class WayPointOutOfBounds(Exception):
+class WayPointOutOfBoundsError(Exception):
     "Raised when the waypoint is out of bounds of the mesh"
 
     def __init__(self, waypoint, message="Waypoint is out of bounds of the mesh"):
         self.message = "Waypoint at " + str(waypoint) + " is out of bounds of the mesh"
         super().__init__(self.message)
 
-class NoRouteFound(Exception):
+class NoRouteFoundError(Exception):
     "Raised when a route cannot be found between two waypoints"
 
     def __init__(self, message="No route found"):
         self.message = message
         super().__init__(self.message)
 
-class InaccessibleWaypoint(Exception):
+class InaccessibleWaypointError(Exception):
     "Raised when a waypoint is inaccessible"
 
     def __init__(self, waypoint, message="Waypoint is inaccessible"):
         self.message = "Waypoint at " + str(waypoint) + " is inaccessible"
         super().__init__(self.message)
 
-class RouteCouldNotSmooth(Exception):
+class RouteCouldNotSmoothError(Exception):
     "Raised when a route cannot be smoothed"
 
     def __init__(self, message="Route could not be smoothed"):
         self.message = message
         super().__init__(self.message)
 
-class InvalidMesh(Exception):
+class InvalidMeshError(Exception):
     "Raised when the mesh is invalid"
 
     def __init__(self, message="Invalid mesh"):

--- a/polar_route/exceptions.py
+++ b/polar_route/exceptions.py
@@ -1,0 +1,17 @@
+"""
+    This module contains the custom exceptions for the polar_route package.
+"""
+
+class WayPointOutOfBounds(Exception):
+    "Raised when the waypoint is out of bounds of the mesh"
+
+    def __init__(self, message="Waypoint is out of bounds of the mesh"):
+        self.message = message
+        super().__init__(self.message)
+
+class NoRouteFound(Exception):
+    "Raised when the route is not found"
+
+    def __init__(self, message="No route found"):
+        self.message = message
+        super().__init__(self.message)

--- a/polar_route/exceptions.py
+++ b/polar_route/exceptions.py
@@ -2,7 +2,7 @@
     This module contains the custom exceptions for the polar_route package.
 """
 
-class WayPointOutOfBoundsError(Exception):
+class WaypointOutOfBoundsError(Exception):
     "Raised when the waypoint is out of bounds of the mesh"
 
     def __init__(self, waypoint, message="Waypoint is out of bounds of the mesh"):
@@ -23,7 +23,7 @@ class InaccessibleWaypointError(Exception):
         self.message = "Waypoint at " + str(waypoint) + " is inaccessible"
         super().__init__(self.message)
 
-class RouteCouldNotSmoothError(Exception):
+class RouteSmoothingError(Exception):
     "Raised when a route cannot be smoothed"
 
     def __init__(self, message="Route could not be smoothed"):

--- a/polar_route/route_calc.py
+++ b/polar_route/route_calc.py
@@ -8,7 +8,6 @@ from shapely.geometry import Point, LineString, MultiLineString, Polygon
 from polar_route.utils import gpx_route_import
 from polar_route.route_planner.crossing import traveltime_in_cell
 from polar_route.route_planner.crossing_smoothing import rhumb_line_distance, dist_around_globe
-from polar_route.route_planner.exceptions import WayPointOutOfBounds, NoRouteFound
 
 
 # Define ordering of cases in array data

--- a/polar_route/route_calc.py
+++ b/polar_route/route_calc.py
@@ -8,6 +8,7 @@ from shapely.geometry import Point, LineString, MultiLineString, Polygon
 from polar_route.utils import gpx_route_import
 from polar_route.route_planner.crossing import traveltime_in_cell
 from polar_route.route_planner.crossing_smoothing import rhumb_line_distance, dist_around_globe
+from polar_route.route_planner.exceptions import WayPointOutOfBounds, NoRouteFound
 
 
 # Define ordering of cases in array data

--- a/polar_route/route_planner/crossing_smoothing.py
+++ b/polar_route/route_planner/crossing_smoothing.py
@@ -3,6 +3,7 @@ import pyproj
 import logging
 from polar_route.route_planner.crossing import traveltime_in_cell
 from polar_route.utils import unit_time, unit_speed, case_from_angle
+from polar_route.exceptions import WayPointOutOfBounds, NoRouteFound, InaccessibleWaypoint, RouteCouldNotSmooth, InvalidMesh
 
 
 def dist_around_globe(start_point,crossing_point):
@@ -378,7 +379,7 @@ class Smoothing:
                         else:
                             y0 = (try_num - 3) * -Y
                 if iter_number > 1000:
-                    raise Exception('Newton Curve Issue - Longitude Case')
+                    raise RouteCouldNotSmooth('Newton Curve Issue - Longitude Case')
             return y0
 
         def _F(y,x,a,Y,u1,v1,u2,v2,speed_s,speed_e,R,λ_s,φ_r):
@@ -562,7 +563,7 @@ class Smoothing:
                         else:
                             y0 = 0
                 if iter_number > 1000:
-                    raise Exception('Newton Curve Issue - Latitude Case')
+                    raise RouteCouldNotSmooth('Newton Curve Issue - Latitude Case')
             return y0
 
         def _F(y, x, a, Y, u1, v1, u2, v2, speed_s, speed_e, R, λ, θ, ψ):
@@ -807,7 +808,7 @@ class Smoothing:
                 case_b = -case
                 return case_a, case_b
 
-        raise Exception('Path Smoothing - Failure - Adding additional cases unknown in neighbour_case')
+        raise RouteCouldNotSmooth('Path Smoothing - Failure - Adding additional cases unknown in neighbour_case')
 
     def _neighbour_indices(self, cell_a, cell_b, case, add_case_a, add_case_b):
         """
@@ -1343,7 +1344,7 @@ class Smoothing:
                 # Updating crossing point
                 midpoint_prime = self.newton_smooth(ap.start, ap.end, ap.case, firstpoint, midpoint, lastpoint)
                 if type(midpoint_prime) == type(None) or np.isnan(midpoint_prime[0]) or np.isnan(midpoint_prime[1]):
-                    raise Exception('Newton call failed to converge or recover')
+                    raise RouteCouldNotSmooth('Newton call failed to converge or recover')
 
                 # Determining if additional cases need to be added
                 add_indices, add_cases = self.nearest_neighbour(ap.start, ap.end, ap.case, midpoint_prime)

--- a/polar_route/route_planner/crossing_smoothing.py
+++ b/polar_route/route_planner/crossing_smoothing.py
@@ -3,7 +3,7 @@ import pyproj
 import logging
 from polar_route.route_planner.crossing import traveltime_in_cell
 from polar_route.utils import unit_time, unit_speed, case_from_angle
-from polar_route.exceptions import WayPointOutOfBoundsError, NoRouteFoundError, InaccessibleWaypointError, RouteCouldNotSmoothError, InvalidMeshError
+from polar_route.exceptions import WaypointOutOfBoundsError, NoRouteFoundError, InaccessibleWaypointError, RouteSmoothingError, InvalidMeshError
 
 
 def dist_around_globe(start_point,crossing_point):
@@ -379,7 +379,7 @@ class Smoothing:
                         else:
                             y0 = (try_num - 3) * -Y
                 if iter_number > 1000:
-                    raise RouteCouldNotSmoothError('Newton Curve Issue - Longitude Case')
+                    raise RouteSmoothingError('Newton Curve Issue - Longitude Case')
             return y0
 
         def _F(y,x,a,Y,u1,v1,u2,v2,speed_s,speed_e,R,λ_s,φ_r):
@@ -563,7 +563,7 @@ class Smoothing:
                         else:
                             y0 = 0
                 if iter_number > 1000:
-                    raise RouteCouldNotSmoothError('Newton Curve Issue - Latitude Case')
+                    raise RouteSmoothingError('Newton Curve Issue - Latitude Case')
             return y0
 
         def _F(y, x, a, Y, u1, v1, u2, v2, speed_s, speed_e, R, λ, θ, ψ):
@@ -808,7 +808,7 @@ class Smoothing:
                 case_b = -case
                 return case_a, case_b
 
-        raise RouteCouldNotSmoothError('Path Smoothing - Failure - Adding additional cases unknown in neighbour_case')
+        raise RouteSmoothingError('Path Smoothing - Failure - Adding additional cases unknown in neighbour_case')
 
     def _neighbour_indices(self, cell_a, cell_b, case, add_case_a, add_case_b):
         """
@@ -1344,7 +1344,7 @@ class Smoothing:
                 # Updating crossing point
                 midpoint_prime = self.newton_smooth(ap.start, ap.end, ap.case, firstpoint, midpoint, lastpoint)
                 if type(midpoint_prime) == type(None) or np.isnan(midpoint_prime[0]) or np.isnan(midpoint_prime[1]):
-                    raise RouteCouldNotSmoothError('Newton call failed to converge or recover')
+                    raise RouteSmoothingError('Newton call failed to converge or recover')
 
                 # Determining if additional cases need to be added
                 add_indices, add_cases = self.nearest_neighbour(ap.start, ap.end, ap.case, midpoint_prime)

--- a/polar_route/route_planner/crossing_smoothing.py
+++ b/polar_route/route_planner/crossing_smoothing.py
@@ -3,7 +3,7 @@ import pyproj
 import logging
 from polar_route.route_planner.crossing import traveltime_in_cell
 from polar_route.utils import unit_time, unit_speed, case_from_angle
-from polar_route.exceptions import WayPointOutOfBounds, NoRouteFound, InaccessibleWaypoint, RouteCouldNotSmooth, InvalidMesh
+from polar_route.exceptions import WayPointOutOfBoundsError, NoRouteFoundError, InaccessibleWaypointError, RouteCouldNotSmoothError, InvalidMeshError
 
 
 def dist_around_globe(start_point,crossing_point):
@@ -379,7 +379,7 @@ class Smoothing:
                         else:
                             y0 = (try_num - 3) * -Y
                 if iter_number > 1000:
-                    raise RouteCouldNotSmooth('Newton Curve Issue - Longitude Case')
+                    raise RouteCouldNotSmoothError('Newton Curve Issue - Longitude Case')
             return y0
 
         def _F(y,x,a,Y,u1,v1,u2,v2,speed_s,speed_e,R,λ_s,φ_r):
@@ -563,7 +563,7 @@ class Smoothing:
                         else:
                             y0 = 0
                 if iter_number > 1000:
-                    raise RouteCouldNotSmooth('Newton Curve Issue - Latitude Case')
+                    raise RouteCouldNotSmoothError('Newton Curve Issue - Latitude Case')
             return y0
 
         def _F(y, x, a, Y, u1, v1, u2, v2, speed_s, speed_e, R, λ, θ, ψ):
@@ -808,7 +808,7 @@ class Smoothing:
                 case_b = -case
                 return case_a, case_b
 
-        raise RouteCouldNotSmooth('Path Smoothing - Failure - Adding additional cases unknown in neighbour_case')
+        raise RouteCouldNotSmoothError('Path Smoothing - Failure - Adding additional cases unknown in neighbour_case')
 
     def _neighbour_indices(self, cell_a, cell_b, case, add_case_a, add_case_b):
         """
@@ -1344,7 +1344,7 @@ class Smoothing:
                 # Updating crossing point
                 midpoint_prime = self.newton_smooth(ap.start, ap.end, ap.case, firstpoint, midpoint, lastpoint)
                 if type(midpoint_prime) == type(None) or np.isnan(midpoint_prime[0]) or np.isnan(midpoint_prime[1]):
-                    raise RouteCouldNotSmooth('Newton call failed to converge or recover')
+                    raise RouteCouldNotSmoothError('Newton call failed to converge or recover')
 
                 # Determining if additional cases need to be added
                 add_indices, add_cases = self.nearest_neighbour(ap.start, ap.end, ap.case, midpoint_prime)

--- a/polar_route/route_planner/route_planner.py
+++ b/polar_route/route_planner/route_planner.py
@@ -22,7 +22,7 @@ from polar_route.route_planner.crossing_smoothing import Smoothing, FindEdge, Pa
 from polar_route.config_validation.config_validator import validate_route_config
 from polar_route.config_validation.config_validator import validate_waypoints
 from polar_route.utils import json_str, unit_speed, pandas_dataframe_str, case_from_angle, timed_call
-from polar_route.exceptions import WayPointOutOfBoundsError, NoRouteFoundError, InaccessibleWaypointError, RouteCouldNotSmoothError, InvalidMeshError
+from polar_route.exceptions import WaypointOutOfBoundsError, NoRouteFoundError, InaccessibleWaypointError, RouteSmoothingError, InvalidMeshError
 
 from meshiphi import Boundary
 from meshiphi.mesh_generation.environment_mesh import EnvironmentMesh

--- a/polar_route/route_planner/route_planner.py
+++ b/polar_route/route_planner/route_planner.py
@@ -22,7 +22,7 @@ from polar_route.route_planner.crossing_smoothing import Smoothing, FindEdge, Pa
 from polar_route.config_validation.config_validator import validate_route_config
 from polar_route.config_validation.config_validator import validate_waypoints
 from polar_route.utils import json_str, unit_speed, pandas_dataframe_str, case_from_angle, timed_call
-from polar_route.route_planner.exceptions import WayPointOutOfBounds, NoRouteFound, InaccessibleWaypoint, RouteCouldNotSmooth, InvalidMesh
+from polar_route.exceptions import WayPointOutOfBounds, NoRouteFound, InaccessibleWaypoint, RouteCouldNotSmooth, InvalidMesh
 
 from meshiphi import Boundary
 from meshiphi.mesh_generation.environment_mesh import EnvironmentMesh

--- a/polar_route/route_planner/route_planner.py
+++ b/polar_route/route_planner/route_planner.py
@@ -22,6 +22,8 @@ from polar_route.route_planner.crossing_smoothing import Smoothing, FindEdge, Pa
 from polar_route.config_validation.config_validator import validate_route_config
 from polar_route.config_validation.config_validator import validate_waypoints
 from polar_route.utils import json_str, unit_speed, pandas_dataframe_str, case_from_angle, timed_call
+from polar_route.route_planner.exceptions import WayPointOutOfBounds, NoRouteFound, InaccessibleWaypoint, RouteCouldNotSmooth, InvalidMesh
+
 from meshiphi import Boundary
 from meshiphi.mesh_generation.environment_mesh import EnvironmentMesh
 from meshiphi.mesh_generation.direction import Direction
@@ -268,13 +270,13 @@ class RoutePlanner:
 
         # Check for totally inaccessible mesh
         if all(cb.agg_data['inaccessible'] for cb in self.cellboxes_lookup.values()):
-            raise ValueError('The environment mesh contains no accessible cells, routing is impossible!')
+            raise InvalidMesh('The environment mesh contains no accessible cells, routing is impossible!')
 
         # Check that the provided mesh has vector information (ex. current)
         self.vector_names = self.config['vector_names']
         for name in self.vector_names: 
              if not any(name in cb.agg_data for cb in self.cellboxes_lookup.values()):
-                 raise ValueError(f'The environment mesh does not contain {name} data and it is a prerequisite for the '
+                 raise InvalidMesh(f'The environment mesh does not contain {name} data and it is a prerequisite for the '
                                   f'route planner!')
         # Check for SIC data, used in smoothed route construction
         if not any('SIC' in cb.agg_data for cb in self.cellboxes_lookup.values()):
@@ -282,12 +284,12 @@ class RoutePlanner:
         
         # Check if speed is defined in the environment mesh
         if not any('speed' in cb.agg_data for cb in self.cellboxes_lookup.values()):
-            raise ValueError('Vessel speed not in the mesh information! Please run vessel performance')
+            raise InvalidMesh('Vessel speed not in the mesh information! Please run vessel performance')
         
         # Check if objective function is in the environment mesh (e.g. speed)
         if self.config['objective_function'] != 'traveltime':
             if not any(self.config['objective_function'] in cb.agg_data for cb in self.cellboxes_lookup.values()):
-                raise ValueError(f"Objective Function '{self.config['objective_function']}' requires the mesh cellboxes"
+                raise InvalidMesh(f"Objective Function '{self.config['objective_function']}' requires the mesh cellboxes"
                                  f" to have '{self.config['objective_function']}' in the aggregated data")
 
         # ====== Defining the cost function ======
@@ -649,9 +651,9 @@ class RoutePlanner:
         src_wps = [SourceWaypoint(wp, end_wps) for wp in src_wps]
         self.src_wps.append(src_wps)
         if not src_wps:
-            raise ValueError('Invalid waypoints. No accessible source waypoints specified')
+            raise NoRouteFound('Invalid waypoints. No accessible source waypoints specified')
         if not end_wps:
-            raise ValueError('Invalid waypoints. No accessible destination waypoints specified')
+            raise NoRouteFound('Invalid waypoints. No accessible destination waypoints specified')
 
         logging.info('============= Dijkstra Route Creation ============')
         logging.info(f" - Objective = {self.config['objective_function']}")
@@ -676,7 +678,7 @@ class RoutePlanner:
         # ====== Routes info =======
         # Check whether any Dijkstra routes exist before running smoothing
         if not self.routes_dijkstra:
-            raise Exception('Smoothed routes not constructed as there were no Dijkstra routes created')
+            raise NoRouteFound("No Dijkstra route before attempting to smooth routes")
         routes = copy.deepcopy(self.routes_dijkstra)
 
         # ====== Determining route info ======


### PR DESCRIPTION
# PolarRoute Pull Request Template

Date: 21/01/2025
Version Number: 1.1.3 -> 11.4
 
## Description of change
Adding custom exception classes for easier failure detection in the pipeline. 

## Fixes # (issue)
[<!--- If this PR adds functionality or resolves problems associated with an issue on GitHub, please include a link to the issue -->](https://github.com/antarctica/PolarRoute/issues/311)

# Testing
To ensure that the functionality of the PolarRoute codebase remains consistent throughout the development cycle a testing strategy has been developed, which can be viewed in the document `test/testing_strategy.md`. 
This includes a collection of test files which should be run according to which part of the codebase has been altered in a pull request. Please consult the testing strategy to determine which tests need to be run. 

- [ ] My changes have not altered any of the files listed in the testing strategy

- [X] My changes result in all required regression tests passing without the need to update test files.  
  
> *list which files have been altered and include a pytest.txt file for each of
> the tests required to be run*
>
> The files which have been changed during this PR can be listed using the command
[reg_tests.txt](https://github.com/user-attachments/files/18492880/reg_tests.txt)

    git diff --name-only 1.1.x

polar_route/__init__.py
polar_route/exceptions.py
polar_route/route_calc.py
polar_route/route_planner/crossing_smoothing.py
polar_route/route_planner/route_planner.py

- [ ] My changes require one or more test files to be updated for all regression tests to pass.   

> *include pytest.txt file showing which tests fail.*  
> *include reasoning as to why your changes cause these tests to fail.* 
>
> Should these changes be valid, relevant test files should be updated.  
> *include pytest.txt file of test passing after test files have been updated.*

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `1.1.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
