### PR TITLE
Fix setuptools packages find, add vesselfactory to init

### DIFF
--- a/polar_route/__init__.py
+++ b/polar_route/__init__.py
@@ -12,6 +12,7 @@ try:
     from meshiphi.mesh_generation.boundary import Boundary as Boundary
 
     from polar_route.vessel_performance.vessel_performance_modeller import VesselPerformanceModeller as VesselPerformanceModeller
+    from polar_route.vessel_performance.vessel_factory import VesselFactory as VesselFactory
     from polar_route.route_planner.route_planner import RoutePlanner as RoutePlanner
     from polar_route.exceptions import WaypointOutOfBoundsError, NoRouteFoundError, InaccessibleWaypointError, RouteSmoothingError, InvalidMeshError
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ keywords= ["Polar Science",
 dynamic = ["version", "dependencies", "optional-dependencies"]
 
 [tool.setuptools]
-packages = ["polar_route"]
+packages = {find = {}}
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}


### PR DESCRIPTION
Fix to module visibility in non-editable installation of polar-route. Also adding `VesselFactory` class to `__init__.py`, as this will be required for PolarRoute-server's vehicle features.